### PR TITLE
Feat/evaluator continued

### DIFF
--- a/src/aiai_eval/config.py
+++ b/src/aiai_eval/config.py
@@ -46,22 +46,60 @@ class Label:
 
 @dataclass
 class DatasetTask:
-    """A dataset task.
+    """Configuration for a task dataset.
     Attributes:
         name (str):
-            The name of the task.
+            The name of the task. Must be lower case with no spaces.
+        dataset_name (str):
+            The name of the task dataset. Must be lower case with no spaces.
+        pretty_dataset_name (str):
+            A longer prettier name for the dataset, which allows cases and spaces. Used
+            for logging.
+        huggingface_id (str):
+            The Hugging Face ID of the dataset.
         supertask (str):
             The supertask of the task, describing the overall type of task.
         metrics (sequence of MetricConfig objects):
             The metrics used to evaluate the task.
         labels (sequence of Label objects):
             The labels used in the task.
+        id2label (list of str):
+            The mapping from ID to label.
+        label2id (dict of str to int):
+            The mapping from label to ID. This includes all label synonyms as well.
+        num_labels (int):
+            The number of labels in the dataset.
+        label_synonyms (list of list of str):
+            The synonyms of all the labels, including the main label.
     """
 
     name: str
+    dataset_name: str
+    pretty_dataset_name: str
+    huggingface_id: str
     supertask: str
     metrics: Sequence[MetricConfig]
     labels: Sequence[Label]
+
+    @property
+    def id2label(self) -> List[str]:
+        return [label.name for label in self.labels]
+
+    @property
+    def label2id(self) -> Dict[str, int]:
+        return {
+            syn: idx
+            for idx, label in enumerate(self.labels)
+            for syn in [label.name] + label.synonyms
+        }
+
+    @property
+    def num_labels(self) -> int:
+        return len(self.labels)
+
+    @property
+    def label_synonyms(self) -> List[List[str]]:
+        return [[label.name] + label.synonyms for label in self.labels]
 
 
 @dataclass
@@ -103,52 +141,3 @@ class EvaluationConfig:
     save_results: bool
     verbose: bool
     testing: bool = False
-
-
-@dataclass
-class DatasetConfig:
-    """Configuration for a dataset.
-    Attributes:
-        name (str):
-            The name of the dataset. Must be lower case with no spaces.
-        pretty_name (str):
-            A longer prettier name for the dataset, which allows cases and spaces. Used
-            for logging.
-        huggingface_id (str):
-            The Hugging Face ID of the dataset.
-        task (DatasetTask):
-            The task of the dataset.
-        id2label (list of str):
-            The mapping from ID to label.
-        label2id (dict of str to int):
-            The mapping from label to ID. This includes all label synonyms as well.
-        num_labels (int):
-            The number of labels in the dataset.
-        label_synonyms (list of list of str):
-            The synonyms of all the labels, including the main label.
-    """
-
-    name: str
-    pretty_name: str
-    huggingface_id: str
-    task: DatasetTask
-
-    @property
-    def id2label(self) -> List[str]:
-        return [label.name for label in self.task.labels]
-
-    @property
-    def label2id(self) -> Dict[str, int]:
-        return {
-            syn: idx
-            for idx, label in enumerate(self.task.labels)
-            for syn in [label.name] + label.synonyms
-        }
-
-    @property
-    def num_labels(self) -> int:
-        return len(self.task.labels)
-
-    @property
-    def label_synonyms(self) -> List[List[str]]:
-        return [[label.name] + label.synonyms for label in self.task.labels]

--- a/src/aiai_eval/evaluator.py
+++ b/src/aiai_eval/evaluator.py
@@ -40,6 +40,7 @@ class Evaluator:
             specified then it will be used as the token. Defaults to False.
         verbose (bool, optional):
             Whether to output additional output. Defaults to False.
+            
     Attributes:
         progress_bar (bool): Whether progress bars should be shown.
         save_results (bool): Whether to save the benchmark results.

--- a/src/aiai_eval/evaluator.py
+++ b/src/aiai_eval/evaluator.py
@@ -16,6 +16,7 @@ logger = logging.getLogger(__name__)
 
 class Evaluator:
     """Evaluating provided Danish language models.
+    
     Args:
         progress_bar (bool, optional):
             Whether progress bars should be shown. Defaults to True.

--- a/src/aiai_eval/evaluator.py
+++ b/src/aiai_eval/evaluator.py
@@ -133,23 +133,18 @@ class Evaluator:
 
     def _prepare_model_ids(
         self,
-        model_id: Optional[Union[Sequence[str], str]],
+        model_id: Union[Sequence[str], str],
     ) -> Sequence[str]:
         """Prepare the model ID(s) to be evaluated.
         Args:
-            model_id (str, list of str or None):
-                The model ID(s) of the models to evaluate. If None then all model IDs
-                will be retrieved.
+            model_id (str, list of str):
+                The model ID(s) of the models to evaluate.
         Returns:
             sequence of str:
                 The prepared list of model IDs.
         """
         model_ids: Sequence[str]
-        if model_id is None:
-            model_ids = self._get_fresh_model_ids(
-                tasks=self.evaluation_config.model_tasks,
-            )
-        elif isinstance(model_id, str):
+        if isinstance(model_id, str):
             model_ids = [model_id]
         else:
             model_ids = model_id
@@ -195,49 +190,8 @@ class Evaluator:
                 )
                 logger.debug(f'The error message was "{e}".')
 
-    def __call__(self, *args, **kwargs):
-        return self.evaluate(*args, **kwargs)
-
-    def _get_fresh_model_ids(
-        self,
-        tasks: Optional[Sequence[str]],
-    ) -> list:
-        """Get list of model IDs from the Hugging Face Hub.
-
-        Args:
-            tasks (None or sequence of str):
-                The tasks of the models to fetch. If None then the models will not be
-                filtered on tasks.
-
-        Returns:
-            list:
-                List of model IDs.
-        """
-        # Specify boolean variables determining whether the input variables are new
-        new_tasks = (
-            self._model_lists is not None
-            and tasks is not None
-            and any(task not in self._model_lists for task in tasks)
-        )
-
-        # If the model lists have not been fetched already, then do it
-        if self._model_lists is None or new_tasks:
-            self._model_lists = get_model_lists(
-                tasks=tasks,
-                use_auth_token=self.evaluation_config.use_auth_token,
-            )
-
-        # Extract all the model IDs from the model lists
-        model_ids: List[str] = list()
-        if tasks is not None:
-            for task in tasks:
-                model_ids.extend(self._model_lists[task])  # type: ignore
-        model_ids.extend(self._model_lists["multilingual"])  # type: ignore
-
-        # Remove duplicate model IDs
-        model_ids = list(set(model_ids))
-
-        return model_ids
+    def __call__(self, model_id: Union[Sequence[str], str]):
+        return self.evaluate(model_id)
 
     def _prepare_dataset_tasks(
         self, dataset_task: Optional[Union[str, Sequence[str]]]

--- a/src/aiai_eval/exceptions.py
+++ b/src/aiai_eval/exceptions.py
@@ -1,1 +1,9 @@
 """Custom exceptions used in the project."""
+
+
+class InvalidEvaluation(Exception):
+    def __init__(
+        self, message: str = "This model cannot be evaluated on the given dataset."
+    ):
+        self.message = message
+        super().__init__(self.message)

--- a/src/aiai_eval/exceptions.py
+++ b/src/aiai_eval/exceptions.py
@@ -7,3 +7,13 @@ class InvalidEvaluation(Exception):
     ):
         self.message = message
         super().__init__(self.message)
+
+
+class ModelDoesNotExistOnHuggingFaceHubException(Exception):
+    def __init__(
+        self,
+        model_id: str,
+    ):
+        self.model_id = model_id
+        self.message = f"The model {model_id} does not exist on the Hugging Face Hub"
+        super().__init__(self.message)

--- a/src/aiai_eval/hf_hub.py
+++ b/src/aiai_eval/hf_hub.py
@@ -4,6 +4,14 @@ from huggingface_hub.utils import RepositoryNotFoundError
 
 
 def model_exists_on_hf_hub(model_id: str) -> bool:
+    """Function checks if `model_id` exists on Huggingface Hub.
+
+    Args:
+        model_id (str): The model ID to check.
+
+    Returns:
+        bool: If model exists on Hugginface Hub or not.
+    """
     hf_api = HfApi()
     try:
         hf_api.model_info(model_id)

--- a/src/aiai_eval/hf_hub.py
+++ b/src/aiai_eval/hf_hub.py
@@ -1,25 +1,12 @@
 """Functions related to the Hugging Face Hub."""
+from huggingface_hub import HfApi
+from huggingface_hub.utils import RepositoryNotFoundError
 
-from typing import Dict, Optional, Sequence, Union
 
-
-# TODO: port this from ScandEval
-def get_model_lists(
-    tasks: Optional[Sequence[str]],
-    use_auth_token: Union[bool, str],
-) -> Dict[str, Sequence[str]]:
-    """Fetches up-to-date model lists.
-    Args:
-        tasks (None or sequence of str):
-            The task to consider. If None then the models will not be filtered on task.
-        use_auth_token (bool or str):
-            The authentication token for the Hugging Face Hub. If a boolean value is
-            specified then the token will be fetched from the Hugging Face CLI, where
-            the user has logged in through `huggingface-cli login`. If a string is
-            specified then it will be used as the token. Defaults to False.
-    Returns:
-        dict:
-            The keys are filterings of the list, all tasks, as well as 'all'. The values are lists
-            of model IDs.
-    """
-    pass
+def model_exists_on_hf_hub(model_id: str) -> bool:
+    hf_api = HfApi()
+    try:
+        hf_api.model_info(model_id)
+        return True
+    except RepositoryNotFoundError:
+        return False

--- a/src/aiai_eval/hf_hub.py
+++ b/src/aiai_eval/hf_hub.py
@@ -10,9 +10,6 @@ def get_model_lists(
 ) -> Dict[str, Sequence[str]]:
     """Fetches up-to-date model lists.
     Args:
-        languages (None or sequence of Language objects):
-            The language codes of the language to consider. If None then the models
-            will not be filtered on language.
         tasks (None or sequence of str):
             The task to consider. If None then the models will not be filtered on task.
         use_auth_token (bool or str):
@@ -22,8 +19,7 @@ def get_model_lists(
             specified then it will be used as the token. Defaults to False.
     Returns:
         dict:
-            The keys are filterings of the list, which includes all language codes,
-            including 'multilingual', all tasks, as well as 'all'. The values are lists
+            The keys are filterings of the list, all tasks, as well as 'all'. The values are lists
             of model IDs.
     """
     pass

--- a/src/aiai_eval/hf_hub.py
+++ b/src/aiai_eval/hf_hub.py
@@ -1,1 +1,29 @@
 """Functions related to the Hugging Face Hub."""
+
+from typing import Dict, Optional, Sequence, Union
+
+
+# TODO: port this from ScandEval
+def get_model_lists(
+    tasks: Optional[Sequence[str]],
+    use_auth_token: Union[bool, str],
+) -> Dict[str, Sequence[str]]:
+    """Fetches up-to-date model lists.
+    Args:
+        languages (None or sequence of Language objects):
+            The language codes of the language to consider. If None then the models
+            will not be filtered on language.
+        tasks (None or sequence of str):
+            The task to consider. If None then the models will not be filtered on task.
+        use_auth_token (bool or str):
+            The authentication token for the Hugging Face Hub. If a boolean value is
+            specified then the token will be fetched from the Hugging Face CLI, where
+            the user has logged in through `huggingface-cli login`. If a string is
+            specified then it will be used as the token. Defaults to False.
+    Returns:
+        dict:
+            The keys are filterings of the list, which includes all language codes,
+            including 'multilingual', all tasks, as well as 'all'. The values are lists
+            of model IDs.
+    """
+    pass

--- a/src/aiai_eval/task_configs.py
+++ b/src/aiai_eval/task_configs.py
@@ -7,6 +7,7 @@ from .config import DatasetTask, Label, MetricConfig
 
 def get_all_dataset_tasks() -> Dict[str, DatasetTask]:
     """Get a list of all the dataset tasks.
+    
     Returns:
         dict:
             A mapping between names of dataset tasks and their configurations.

--- a/src/aiai_eval/task_configs.py
+++ b/src/aiai_eval/task_configs.py
@@ -15,37 +15,6 @@ def get_all_dataset_tasks() -> Dict[str, DatasetTask]:
     return {cfg.name: cfg for cfg in globals().values() if isinstance(cfg, DatasetTask)}
 
 
-LA = DatasetTask(
-    name="la",
-    supertask="text-classification",
-    metrics=[
-        MetricConfig(
-            name="mcc",
-            pretty_name="Matthew's Correlation Coefficient",
-            huggingface_id="matthews_correlation",
-            results_key="matthews_correlation",
-        ),
-        MetricConfig(
-            name="macro_f1",
-            pretty_name="Macro-average F1-score",
-            huggingface_id="f1",
-            results_key="f1",
-            compute_kwargs=dict(average="macro"),
-        ),
-    ],
-    labels=[
-        Label(
-            name="INCORRECT",
-            synonyms=["LABEL_0"],
-        ),
-        Label(
-            name="CORRECT",
-            synonyms=["LABEL_1"],
-        ),
-    ],
-)
-
-
 NER = DatasetTask(
     name="ner",
     supertask="token-classification",

--- a/src/aiai_eval/task_configs.py
+++ b/src/aiai_eval/task_configs.py
@@ -7,7 +7,7 @@ from .config import DatasetTask, Label, MetricConfig
 
 def get_all_dataset_tasks() -> Dict[str, DatasetTask]:
     """Get a list of all the dataset tasks.
-    
+
     Returns:
         dict:
             A mapping between names of dataset tasks and their configurations.
@@ -17,6 +17,9 @@ def get_all_dataset_tasks() -> Dict[str, DatasetTask]:
 
 NER = DatasetTask(
     name="ner",
+    dataset_name="dane",
+    pretty_dataset_name="the truncated version of DaNE",
+    huggingface_id="ScandEval/dane-mini",
     supertask="token-classification",
     metrics=[
         MetricConfig(
@@ -159,29 +162,11 @@ NER = DatasetTask(
 )
 
 
-QA = DatasetTask(
-    name="qa",
-    supertask="question-answering",
-    metrics=[
-        MetricConfig(
-            name="em",
-            pretty_name="Exact Match",
-            huggingface_id="exact_match",
-            results_key="exact_match",
-        ),
-        MetricConfig(
-            name="f1",
-            pretty_name="F1-score of the positive class",
-            huggingface_id="f1",
-            results_key="f1",
-        ),
-    ],
-    labels=[],
-)
-
-
 SENT = DatasetTask(
     name="sent",
+    dataset_name="angry-tweets",
+    pretty_dataset_name="the truncated version of AngryTweets",
+    huggingface_id="ScandEval/angry-tweets-mini",
     supertask="text-classification",
     metrics=[
         MetricConfig(

--- a/src/aiai_eval/task_configs.py
+++ b/src/aiai_eval/task_configs.py
@@ -18,8 +18,8 @@ def get_all_dataset_tasks() -> Dict[str, DatasetTask]:
 NER = DatasetTask(
     name="ner",
     dataset_name="dane",
-    pretty_dataset_name="the truncated version of DaNE",
-    huggingface_id="ScandEval/dane-mini",
+    pretty_dataset_name="The Danish Dependency Treebank",
+    huggingface_id="dane",
     supertask="token-classification",
     metrics=[
         MetricConfig(
@@ -165,8 +165,8 @@ NER = DatasetTask(
 SENT = DatasetTask(
     name="sent",
     dataset_name="angry-tweets",
-    pretty_dataset_name="the truncated version of AngryTweets",
-    huggingface_id="ScandEval/angry-tweets-mini",
+    pretty_dataset_name="Angry Tweets, Danish Twitter data",
+    huggingface_id="DDSC/angry-tweets",
     supertask="text-classification",
     metrics=[
         MetricConfig(

--- a/src/aiai_eval/task_factory.py
+++ b/src/aiai_eval/task_factory.py
@@ -21,14 +21,14 @@ class TaskFactory:
     def __init__(self, evaluation_config: EvaluationConfig):
         self.evaluation_config = evaluation_config
 
-    def build_dataset(self, dataset_task: Union[str, DatasetTask]) -> None:
+    def build_dataset(self, dataset_task: Union[str, DatasetTask]) -> list:
         """Build a dataset from a configuration or a name.
         Args:
             dataset (str or DatasetConfig):
                 The name of the dataset, or the dataset configuration.
         Returns:
-            Implement BenchmarkDataset:
+            dataset (BenchmarkDataset):
                 The benchmark dataset.
         """
         # TODO: implement BenchmarkDataset analog
-        return None
+        return []

--- a/src/aiai_eval/task_factory.py
+++ b/src/aiai_eval/task_factory.py
@@ -2,16 +2,16 @@
 
 from typing import Type, Union
 
-from .config import EvaluationConfig
+from .config import DatasetTask, EvaluationConfig
 
 
 class TaskFactory:
     """Factory which produces tasks from a configuration.
-    
+
     Args:
         evaluation_config (EvaluationConfig):
             The benchmark configuration to be used in all tasks constructed.
-            
+
     Attributes:
         evaluation_config (EvaluationConfig):
             The benchmark configuration to be used in all tasks constructed.
@@ -20,4 +20,14 @@ class TaskFactory:
     def __init__(self, evaluation_config: EvaluationConfig):
         self.evaluation_config = evaluation_config
 
-    # TODO build_dataset(DatasetConfig)
+    def build_dataset(self, dataset_task: Union[str, DatasetTask]) -> None:
+        """Build a dataset from a configuration or a name.
+        Args:
+            dataset (str or DatasetConfig):
+                The name of the dataset, or the dataset configuration.
+        Returns:
+            Implement BenchmarkDataset:
+                The benchmark dataset.
+        """
+        # TODO: implement BenchmarkDataset analog
+        pass

--- a/src/aiai_eval/task_factory.py
+++ b/src/aiai_eval/task_factory.py
@@ -7,9 +7,11 @@ from .config import EvaluationConfig
 
 class TaskFactory:
     """Factory which produces tasks from a configuration.
+    
     Args:
         evaluation_config (EvaluationConfig):
             The benchmark configuration to be used in all tasks constructed.
+            
     Attributes:
         evaluation_config (EvaluationConfig):
             The benchmark configuration to be used in all tasks constructed.

--- a/src/aiai_eval/task_factory.py
+++ b/src/aiai_eval/task_factory.py
@@ -1,5 +1,6 @@
 """Factory that produces tasks from a task configuration."""
 
+from ast import Return
 from typing import Type, Union
 
 from .config import DatasetTask, EvaluationConfig
@@ -30,4 +31,4 @@ class TaskFactory:
                 The benchmark dataset.
         """
         # TODO: implement BenchmarkDataset analog
-        pass
+        return None

--- a/src/aiai_eval/task_factory.py
+++ b/src/aiai_eval/task_factory.py
@@ -1,6 +1,5 @@
 """Factory that produces tasks from a task configuration."""
 
-from ast import Return
 from typing import Type, Union
 
 from .config import DatasetTask, EvaluationConfig


### PR DESCRIPTION
This PR continues the porting of `benchmarker.py` from ScanEval to `evaluator.py`. 

-  Since there is a one-to-one correspondence between tasks and datasets, the function `_prepare_dataset_configs` is removed and 'replaced' by `_prepare_dataset_tasks`.
- In `config.py` the dataclass `DatasetConfig` is merged with `DatasetTask` and is also renamed to `DatasetTask`.
- The remaining references to languages in the methods of `Evaluator` is removed. 
- The instances of `DatasetTask` in `task_configs.py` are updated to fit the updated dataclass.
- The `QA` task is removed for now, and will be reintroduced later when the QA-dataset is published.
- Many functions are just placeholders for now, and some of them have wrong/incomplete type hinting, to circumvent commit hooks. e.g. `build_dataset` in `task_factory.py`.