### PR TITLE
Feat/add cli

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,9 @@ black = "^22.6.0"
 isort = "^5.10.1"
 readme-coverage-badger = ">=0.1.2,<1.0.0"
 
+[tool.poetry.scripts]
+evaluate = "src.aiai_eval.cli:evaluate"
+
 [tool.pytest.ini_options]
 minversion = "6.0"
 addopts = [

--- a/src/aiai_eval/cli.py
+++ b/src/aiai_eval/cli.py
@@ -65,7 +65,7 @@ from .task_configs import get_all_task_configs
 @click.option(
     "--cache-dir",
     "-c",
-    default=".scandeval_cache",
+    default=".aiai_cache",
     show_default=True,
     help="The directory where models are datasets are cached.",
 )

--- a/src/aiai_eval/cli.py
+++ b/src/aiai_eval/cli.py
@@ -23,7 +23,7 @@ from .task_configs import get_all_task_configs
     "-t",
     multiple=True,
     type=click.Choice(list(get_all_task_configs().keys())),
-    help="""The name of the task to evaluate.""",
+    help="""The name(s) of the task(s) to evaluate.""",
 )
 @click.option(
     "--auth-token",

--- a/src/aiai_eval/cli.py
+++ b/src/aiai_eval/cli.py
@@ -1,1 +1,108 @@
 """Command-line interface for evaluation of models."""
+
+from typing import Tuple, Union
+
+import click
+
+from .evaluator import Evaluator
+from .task_configs import get_all_task_configs
+
+
+@click.command()
+@click.argument(
+    "--model-id",
+    "-m",
+    multiple=True,
+    help="""The Hugging Face model ID of the model(s) to be benchmarked. The specific
+    model version to use can be added after the suffix "@": "<model_id>@v1.0.0". It can
+    be a branch name, a tag name, or a commit id (currently only supported for Hugging
+    Face models, and it defaults to "main" for latest).""",
+)
+@click.argument(
+    "--task",
+    "-t",
+    multiple=True,
+    type=click.Choice(list(get_all_task_configs().keys())),
+    help="""The name of the task to evaluate.""",
+)
+@click.option(
+    "--auth-token",
+    type=str,
+    default="",
+    show_default=True,
+    help="""The authentication token for the Hugging Face Hub. If specified then the
+    `--use-auth-token` flag will be set to True.""",
+)
+@click.option(
+    "--use-auth-token",
+    is_flag=True,
+    show_default=True,
+    help="""Whether an authentication token should be used, enabling evaluation of
+            private models. Requires that you are logged in via the
+            `huggingface-cli login` command.""",
+)
+@click.option(
+    "--no-progress-bar",
+    "-np",
+    is_flag=True,
+    show_default=True,
+    help="Whether progress bars should be shown.",
+)
+@click.option(
+    "--no-save-results",
+    "-ns",
+    is_flag=True,
+    show_default=True,
+    help="Whether results should not be stored to disk.",
+)
+@click.option(
+    "--raise-error-on-invalid-model",
+    "-r",
+    is_flag=True,
+    show_default=True,
+    help="Whether to raise an error if a model is invalid.",
+)
+@click.option(
+    "--cache-dir",
+    "-c",
+    default=".scandeval_cache",
+    show_default=True,
+    help="The directory where models are datasets are cached.",
+)
+@click.option(
+    "--verbose",
+    "-v",
+    is_flag=True,
+    show_default=True,
+    help="Whether extra input should be outputted during benchmarking",
+)
+def benchmark(
+    model_id: Tuple[str],
+    task: Tuple[str],
+    auth_token: str,
+    use_auth_token: bool,
+    no_progress_bar: bool,
+    no_save_results: bool,
+    raise_error_on_invalid_model: bool,
+    cache_dir: str,
+    verbose: bool = False,
+):
+    """Benchmark finetuned models."""
+
+    # Set up variables
+    model_ids = list(model_id)
+    tasks = list(task)
+    auth: Union[str, bool] = auth_token if auth_token != "" else use_auth_token
+
+    # Initialise the benchmarker class
+    evaluator = Evaluator(
+        progress_bar=(not no_progress_bar),
+        save_results=(not no_save_results),
+        raise_error_on_invalid_model=raise_error_on_invalid_model,
+        cache_dir=cache_dir,
+        use_auth_token=auth,
+        verbose=verbose,
+    )
+
+    # Perform the benchmark evaluation
+    evaluator(model_id=model_ids, task=tasks)

--- a/src/aiai_eval/cli.py
+++ b/src/aiai_eval/cli.py
@@ -76,7 +76,7 @@ from .task_configs import get_all_task_configs
     show_default=True,
     help="Whether extra input should be outputted during benchmarking",
 )
-def benchmark(
+def evaluate(
     model_id: Tuple[str],
     task: Tuple[str],
     auth_token: str,

--- a/src/aiai_eval/config.py
+++ b/src/aiai_eval/config.py
@@ -47,8 +47,9 @@ class Label:
 
 
 @dataclass
-class DatasetTask:
+class TaskConfig:
     """Configuration for a task dataset.
+
     Attributes:
         name (str):
             The name of the task. Must be lower case with no spaces.
@@ -110,10 +111,6 @@ class EvaluationConfig:
     """General benchmarking configuration, across datasets and models.
 
     Attributes:
-        model_tasks (None or sequence of str):
-            The tasks of the models to benchmark.
-        dataset_tasks (sequence of DatasetTask):
-            The tasks to benchmark.
         raise_error_on_invalid_model (bool):
             Whether to raise an error if a model is invalid.
         cache_dir (str):
@@ -136,8 +133,6 @@ class EvaluationConfig:
             Whether a unit test is being run. Defaults to False.
     """
 
-    model_tasks: Optional[Sequence[str]]
-    dataset_tasks: Sequence[DatasetTask]
     raise_error_on_invalid_model: bool
     cache_dir: str
     use_auth_token: Union[bool, str]

--- a/src/aiai_eval/evaluator.py
+++ b/src/aiai_eval/evaluator.py
@@ -24,11 +24,11 @@ class Evaluator:
             Whether progress bars should be shown. Defaults to True.
         save_results (bool, optional):
             Whether to save the benchmark results to
-            'aiai_eval_results.json'. Defaults to False.
+            'aiai_evaluation_results.json'. Defaults to False.
         raise_error_on_invalid_model (bool, optional):
             Whether to raise an error if a model is invalid. Defaults to False.
         cache_dir (str, optional):
-            Directory to store cached models. Defaults to '.aiai_eval_cache'.
+            Directory to store cached models. Defaults to '.aiai_cache'.
         use_auth_token (bool or str, optional):
             The authentication token for the Hugging Face Hub. If a boolean value is
             specified then the token will be fetched from the Hugging Face CLI, where
@@ -50,7 +50,7 @@ class Evaluator:
         progress_bar: bool = True,
         save_results: bool = False,
         raise_error_on_invalid_model: bool = False,
-        cache_dir: str = ".aiai_eval_cache",
+        cache_dir: str = ".aiai_cache",
         use_auth_token: Union[bool, str] = False,
         verbose: bool = False,
     ):
@@ -111,7 +111,7 @@ class Evaluator:
 
         # Save the evaluation results
         if self.evaluation_config.save_results:
-            output_path = Path.cwd() / "aiai_eval_results.json"
+            output_path = Path.cwd() / "aiai_evaluation_results.json"
             with output_path.open("w") as f:
                 json.dump(self.evaluation_results, f)
 

--- a/src/aiai_eval/named_entity_recognition.py
+++ b/src/aiai_eval/named_entity_recognition.py
@@ -1,22 +1,25 @@
 """Class for the named entity recognition task."""
 
+from typing import Optional
+
 from datasets import Dataset
+from transformers import PreTrainedTokenizerBase
 
-from .task import EvaluationTask
+from .task import Task
 
 
-class NEREvaluation(EvaluationTask):
+class NEREvaluation(Task):
     """NER task.
 
     Args:
-        dataset_task (DatasetTask):
-            The configuration of the dataset task.
+        task_config (TaskConfig):
+            The configuration of the task.
         evaluation_config (EvaluationConfig):
             The configuration of the evaluation.
 
     Attributes:
-        dataset_task (DatasetTask):
-            The configuration of the dataset task.
+        task_config (TaskConfig):
+            The configuration of the task.
         evaluation_config (EvaluationConfig):
             The configuration of the evaluation.
     """
@@ -33,3 +36,17 @@ class NEREvaluation(EvaluationTask):
             Hugging Face dataset: The preprocessed dataset.
         """
         return dataset
+
+    def _load_data_collator(self, tokenizer: Optional[PreTrainedTokenizerBase] = None):
+        """Load the data collator used to prepare samples during finetuning.
+
+        Args:
+            tokenizer (Hugging Face tokenizer or None, optional):
+                A pretrained tokenizer. Can be None if the tokenizer is not used in the
+                initialisation of the data collator. Defaults to None.
+
+        Returns:
+            Hugging Face data collator:
+                The data collator.
+        """
+        pass

--- a/src/aiai_eval/task_configs.py
+++ b/src/aiai_eval/task_configs.py
@@ -5,7 +5,7 @@ from typing import Dict
 from .config import DatasetTask, Label, MetricConfig
 
 
-def get_all_dataset_tasks() -> Dict[str, DatasetTask]:
+def get_all_tasks() -> Dict[str, DatasetTask]:
     """Get a list of all the dataset tasks.
 
     Returns:

--- a/src/aiai_eval/task_configs.py
+++ b/src/aiai_eval/task_configs.py
@@ -2,20 +2,20 @@
 
 from typing import Dict
 
-from .config import DatasetTask, Label, MetricConfig
+from .config import Label, MetricConfig, TaskConfig
 
 
-def get_all_tasks() -> Dict[str, DatasetTask]:
+def get_all_task_configs() -> Dict[str, TaskConfig]:
     """Get a list of all the dataset tasks.
 
     Returns:
         dict:
             A mapping between names of dataset tasks and their configurations.
     """
-    return {cfg.name: cfg for cfg in globals().values() if isinstance(cfg, DatasetTask)}
+    return {cfg.name: cfg for cfg in globals().values() if isinstance(cfg, TaskConfig)}
 
 
-NER = DatasetTask(
+NER = TaskConfig(
     name="ner",
     dataset_name="dane",
     pretty_dataset_name="DaNE",
@@ -163,7 +163,7 @@ NER = DatasetTask(
 )
 
 
-SENT = DatasetTask(
+SENT = TaskConfig(
     name="sent",
     dataset_name="angry-tweets",
     pretty_dataset_name="Angry Tweets",

--- a/src/aiai_eval/text_classification.py
+++ b/src/aiai_eval/text_classification.py
@@ -7,35 +7,35 @@ from datasets import Dataset
 from transformers import DataCollatorWithPadding, PreTrainedTokenizerBase
 
 from .exceptions import InvalidEvaluation
-from .task import EvaluationTask
+from .task import Task
 
 
-class SentimentAnalysis(EvaluationTask):
-    """Sentiment analysis evaluation task.
+class TextClassification(Task):
+    """Text classification task.
 
     Args:
-        dataset_task (DatasetTask):
-            The configuration of the dataset task.
+        task_config (TaskConfig):
+            The configuration of the task.
         evaluation_config (EvaluationConfig):
             The configuration of the evaluation.
 
     Attributes:
-        dataset_task (DatasetTask):
-            The configuration of the dataset task.
+        task_config (TaskConfig):
+            The configuration of the task.
         evaluation_config (EvaluationConfig):
             The configuration of the evaluation.
     """
 
     def _preprocess_data(self, dataset: Dataset, framework: str, **kwargs) -> Dataset:
         """Preprocess a dataset by tokenizing and aligning the labels.
-        
+
         Args:
             dataset (Hugging Face dataset):
                 The dataset to preprocess.
             kwargs:
                 Extra keyword arguments containing objects used in preprocessing the
                 dataset.
-                
+
         Returns:
             Hugging Face dataset: The preprocessed dataset.
         """
@@ -76,14 +76,14 @@ class SentimentAnalysis(EvaluationTask):
             )
         return examples
 
-    def _load_data_collator(self, tokenizer: PreTrainedTokenizerBase):
+    def _load_data_collator(self, tokenizer: Optional[PreTrainedTokenizerBase] = None):
         """Load the data collator used to prepare samples during evaluation.
-        
+
         Args:
             tokenizer (Hugging Face tokenizer or None, optional):
                 A pretrained tokenizer. Can be None if the tokenizer is not used in the
                 initialisation of the data collator. Defaults to None.
-                
+
         Returns:
             Hugging Face data collator:
                 The data collator.
@@ -92,13 +92,13 @@ class SentimentAnalysis(EvaluationTask):
 
     def _get_spacy_predictions_and_labels(self, model, dataset: Dataset) -> tuple:
         """Get predictions from SpaCy model on dataset.
-        
+
         Args:
             model (SpaCy model):
                 The model.
             dataset (Hugging Face dataset):
                 The dataset.
-                
+
         Returns:
             A pair of arrays:
                 The first array contains the probability predictions and the second
@@ -107,20 +107,3 @@ class SentimentAnalysis(EvaluationTask):
         raise InvalidEvaluation(
             "Evaluation of text classification tasks for SpaCy models is not possible."
         )
-
-
-class OffensiveSpeechClassification(EvaluationTask):
-    """Offensive Speech classification evaluation task.
-
-    Args:
-        dataset_task (DatasetTask):
-            The configuration of the dataset task.
-        evaluation_config (EvaluationConfig):
-            The configuration of the evaluation.
-
-    Attributes:
-        dataset_task (DatasetTask):
-            The configuration of the dataset task.
-        evaluation_config (EvaluationConfig):
-            The configuration of the evaluation.
-    """


### PR DESCRIPTION
Add a CLI, and in the process make lots of changes to how we talk about tasks:
- I use `task_name` when I want to emphasise that I'm only talking about a string, the name of the task.
- I use `task_config` to signify a `TaskConfig` object.
- I use `task` to signify a `Task` object.

Note that in `Evaluator.evaluate` I break this custom, as it has the argument `task` but it really accepts a task name. This is solely to make it more intuitive for the end-user, as this is part of the public API.