### PR TITLE
Feat/codecarbon

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -38,6 +38,17 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "arrow"
+version = "1.2.2"
+description = "Better dates & times for Python"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+python-dateutil = ">=2.7.0"
+
+[[package]]
 name = "astunparse"
 version = "1.6.3"
 description = "An AST unparser for Python"
@@ -156,6 +167,27 @@ python-versions = ">=3.7"
 
 [package.dependencies]
 colorama = {version = "*", markers = "platform_system == \"Windows\""}
+
+[[package]]
+name = "codecarbon"
+version = "2.1.3"
+description = ""
+category = "main"
+optional = false
+python-versions = ">3.6"
+
+[package.dependencies]
+arrow = "*"
+click = "*"
+fuzzywuzzy = "*"
+pandas = "*"
+psutil = "*"
+py-cpuinfo = "*"
+pynvml = "*"
+requests = "*"
+
+[package.extras]
+viz = ["fire", "dash-bootstrap-components", "dash"]
 
 [[package]]
 name = "colorama"
@@ -308,6 +340,17 @@ sftp = ["paramiko"]
 smb = ["smbprotocol"]
 ssh = ["paramiko"]
 tqdm = ["tqdm"]
+
+[[package]]
+name = "fuzzywuzzy"
+version = "0.18.0"
+description = "Fuzzy string matching in python"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.extras]
+speedup = ["python-levenshtein (>=0.12)"]
 
 [[package]]
 name = "huggingface-hub"
@@ -644,12 +687,31 @@ optional = false
 python-versions = ">=3.7"
 
 [[package]]
+name = "psutil"
+version = "5.9.1"
+description = "Cross-platform lib for process and system monitoring in Python."
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[package.extras]
+test = ["ipaddress", "mock", "enum34", "pywin32", "wmi"]
+
+[[package]]
 name = "py"
 version = "1.11.0"
 description = "library with cross-python path, ini-parsing, io, code, log facilities"
 category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[[package]]
+name = "py-cpuinfo"
+version = "8.0.0"
+description = "Get CPU info with pure Python 2 & 3"
+category = "main"
+optional = false
+python-versions = "*"
 
 [[package]]
 name = "pyarrow"
@@ -682,6 +744,14 @@ name = "pygments"
 version = "2.12.0"
 description = "Pygments is a syntax highlighting package written in Python."
 category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
+name = "pynvml"
+version = "11.4.1"
+description = "Python Bindings for the NVIDIA Management Library"
+category = "main"
 optional = false
 python-versions = ">=3.6"
 
@@ -1263,7 +1333,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8,<3.11"
-content-hash = "f7c86e338609327df65851bd3654c6843ac8ec27a87a8465b22e30c4e6072c93"
+content-hash = "cbeb761a4795ff023e6b9fef8c541fa29681759698df9e5f90b3373fbb24c203"
 
 [metadata.files]
 aiohttp = [
@@ -1346,6 +1416,10 @@ aiosignal = [
 ]
 antlr4-python3-runtime = [
     {file = "antlr4-python3-runtime-4.9.3.tar.gz", hash = "sha256:f224469b4168294902bb1efa80a8bf7855f24c99aef99cbefc1bcd3cce77881b"},
+]
+arrow = [
+    {file = "arrow-1.2.2-py3-none-any.whl", hash = "sha256:d622c46ca681b5b3e3574fcb60a04e5cc81b9625112d5fb2b44220c36c892177"},
+    {file = "arrow-1.2.2.tar.gz", hash = "sha256:05caf1fd3d9a11a1135b2b6f09887421153b94558e5ef4d090b567b47173ac2b"},
 ]
 astunparse = [
     {file = "astunparse-1.6.3-py2.py3-none-any.whl", hash = "sha256:c2652417f2c8b5bb325c885ae329bdf3f86424075c4fd1a128674bc6fba4b8e8"},
@@ -1432,6 +1506,10 @@ charset-normalizer = [
 click = [
     {file = "click-8.1.3-py3-none-any.whl", hash = "sha256:bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48"},
     {file = "click-8.1.3.tar.gz", hash = "sha256:7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e"},
+]
+codecarbon = [
+    {file = "codecarbon-2.1.3-py3-none-any.whl", hash = "sha256:130d3740a2ace3160a763729fff0a93375a525bccba7d3541cf9c16b5b7a91ad"},
+    {file = "codecarbon-2.1.3.tar.gz", hash = "sha256:2de672e8f19dfc4059dfd2ba960e284c8460b689df11356790af08c85bb7e121"},
 ]
 colorama = [
     {file = "colorama-0.4.5-py2.py3-none-any.whl", hash = "sha256:854bf444933e37f5824ae7bfc1e98d5bce2ebe4160d46b5edf346a89358e99da"},
@@ -1601,6 +1679,10 @@ frozenlist = [
 fsspec = [
     {file = "fsspec-2022.7.1-py3-none-any.whl", hash = "sha256:36c5a8e7c4fc20cf32ef6934ac0a122accc8a593ddc8478d30c3ca4dbbd95500"},
     {file = "fsspec-2022.7.1.tar.gz", hash = "sha256:7f9fb19d811b027b97c4636c6073eb53bc4cbee2d3c4b33fa88b9f26906fd7d7"},
+]
+fuzzywuzzy = [
+    {file = "fuzzywuzzy-0.18.0-py2.py3-none-any.whl", hash = "sha256:928244b28db720d1e0ee7587acf660ea49d7e4c632569cad4f1cd7e68a5f0993"},
+    {file = "fuzzywuzzy-0.18.0.tar.gz", hash = "sha256:45016e92264780e58972dca1b3d939ac864b78437422beecebb3095f8efd00e8"},
 ]
 huggingface-hub = [
     {file = "huggingface_hub-0.8.1-py3-none-any.whl", hash = "sha256:a11fb8d696a26f927833d46b7633105fd864fd92a2beb1140cbf1b2f703dedb3"},
@@ -1922,9 +2004,46 @@ protobuf = [
     {file = "protobuf-4.21.4-py3-none-any.whl", hash = "sha256:7e51f6244e53e936abadf624ab3a0f06dc106b27473997374fbb34e6b2eb1e60"},
     {file = "protobuf-4.21.4.tar.gz", hash = "sha256:5783dc0d6edae631145337fabb18503b4f77274f94cdd22a4b26b9fe5029e718"},
 ]
+psutil = [
+    {file = "psutil-5.9.1-cp27-cp27m-manylinux2010_i686.whl", hash = "sha256:799759d809c31aab5fe4579e50addf84565e71c1dc9f1c31258f159ff70d3f87"},
+    {file = "psutil-5.9.1-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:9272167b5f5fbfe16945be3db475b3ce8d792386907e673a209da686176552af"},
+    {file = "psutil-5.9.1-cp27-cp27m-win32.whl", hash = "sha256:0904727e0b0a038830b019551cf3204dd48ef5c6868adc776e06e93d615fc5fc"},
+    {file = "psutil-5.9.1-cp27-cp27m-win_amd64.whl", hash = "sha256:e7e10454cb1ab62cc6ce776e1c135a64045a11ec4c6d254d3f7689c16eb3efd2"},
+    {file = "psutil-5.9.1-cp27-cp27mu-manylinux2010_i686.whl", hash = "sha256:56960b9e8edcca1456f8c86a196f0c3d8e3e361320071c93378d41445ffd28b0"},
+    {file = "psutil-5.9.1-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:44d1826150d49ffd62035785a9e2c56afcea66e55b43b8b630d7706276e87f22"},
+    {file = "psutil-5.9.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:c7be9d7f5b0d206f0bbc3794b8e16fb7dbc53ec9e40bbe8787c6f2d38efcf6c9"},
+    {file = "psutil-5.9.1-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:abd9246e4cdd5b554a2ddd97c157e292ac11ef3e7af25ac56b08b455c829dca8"},
+    {file = "psutil-5.9.1-cp310-cp310-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:29a442e25fab1f4d05e2655bb1b8ab6887981838d22effa2396d584b740194de"},
+    {file = "psutil-5.9.1-cp310-cp310-win32.whl", hash = "sha256:20b27771b077dcaa0de1de3ad52d22538fe101f9946d6dc7869e6f694f079329"},
+    {file = "psutil-5.9.1-cp310-cp310-win_amd64.whl", hash = "sha256:58678bbadae12e0db55186dc58f2888839228ac9f41cc7848853539b70490021"},
+    {file = "psutil-5.9.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:3a76ad658641172d9c6e593de6fe248ddde825b5866464c3b2ee26c35da9d237"},
+    {file = "psutil-5.9.1-cp36-cp36m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a6a11e48cb93a5fa606306493f439b4aa7c56cb03fc9ace7f6bfa21aaf07c453"},
+    {file = "psutil-5.9.1-cp36-cp36m-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:068935df39055bf27a29824b95c801c7a5130f118b806eee663cad28dca97685"},
+    {file = "psutil-5.9.1-cp36-cp36m-win32.whl", hash = "sha256:0f15a19a05f39a09327345bc279c1ba4a8cfb0172cc0d3c7f7d16c813b2e7d36"},
+    {file = "psutil-5.9.1-cp36-cp36m-win_amd64.whl", hash = "sha256:db417f0865f90bdc07fa30e1aadc69b6f4cad7f86324b02aa842034efe8d8c4d"},
+    {file = "psutil-5.9.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:91c7ff2a40c373d0cc9121d54bc5f31c4fa09c346528e6a08d1845bce5771ffc"},
+    {file = "psutil-5.9.1-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:fea896b54f3a4ae6f790ac1d017101252c93f6fe075d0e7571543510f11d2676"},
+    {file = "psutil-5.9.1-cp37-cp37m-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3054e923204b8e9c23a55b23b6df73a8089ae1d075cb0bf711d3e9da1724ded4"},
+    {file = "psutil-5.9.1-cp37-cp37m-win32.whl", hash = "sha256:d2d006286fbcb60f0b391741f520862e9b69f4019b4d738a2a45728c7e952f1b"},
+    {file = "psutil-5.9.1-cp37-cp37m-win_amd64.whl", hash = "sha256:b14ee12da9338f5e5b3a3ef7ca58b3cba30f5b66f7662159762932e6d0b8f680"},
+    {file = "psutil-5.9.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:19f36c16012ba9cfc742604df189f2f28d2720e23ff7d1e81602dbe066be9fd1"},
+    {file = "psutil-5.9.1-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:944c4b4b82dc4a1b805329c980f270f170fdc9945464223f2ec8e57563139cf4"},
+    {file = "psutil-5.9.1-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4b6750a73a9c4a4e689490ccb862d53c7b976a2a35c4e1846d049dcc3f17d83b"},
+    {file = "psutil-5.9.1-cp38-cp38-win32.whl", hash = "sha256:a8746bfe4e8f659528c5c7e9af5090c5a7d252f32b2e859c584ef7d8efb1e689"},
+    {file = "psutil-5.9.1-cp38-cp38-win_amd64.whl", hash = "sha256:79c9108d9aa7fa6fba6e668b61b82facc067a6b81517cab34d07a84aa89f3df0"},
+    {file = "psutil-5.9.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:28976df6c64ddd6320d281128817f32c29b539a52bdae5e192537bc338a9ec81"},
+    {file = "psutil-5.9.1-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b88f75005586131276634027f4219d06e0561292be8bd6bc7f2f00bdabd63c4e"},
+    {file = "psutil-5.9.1-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:645bd4f7bb5b8633803e0b6746ff1628724668681a434482546887d22c7a9537"},
+    {file = "psutil-5.9.1-cp39-cp39-win32.whl", hash = "sha256:32c52611756096ae91f5d1499fe6c53b86f4a9ada147ee42db4991ba1520e574"},
+    {file = "psutil-5.9.1-cp39-cp39-win_amd64.whl", hash = "sha256:f65f9a46d984b8cd9b3750c2bdb419b2996895b005aefa6cbaba9a143b1ce2c5"},
+    {file = "psutil-5.9.1.tar.gz", hash = "sha256:57f1819b5d9e95cdfb0c881a8a5b7d542ed0b7c522d575706a80bedc848c8954"},
+]
 py = [
     {file = "py-1.11.0-py2.py3-none-any.whl", hash = "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"},
     {file = "py-1.11.0.tar.gz", hash = "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719"},
+]
+py-cpuinfo = [
+    {file = "py-cpuinfo-8.0.0.tar.gz", hash = "sha256:5f269be0e08e33fd959de96b34cd4aeeeacac014dd8305f70eb28d06de2345c5"},
 ]
 pyarrow = [
     {file = "pyarrow-9.0.0-cp310-cp310-macosx_10_13_universal2.whl", hash = "sha256:767cafb14278165ad539a2918c14c1b73cf20689747c21375c38e3fe62884902"},
@@ -1994,6 +2113,10 @@ pydantic = [
 pygments = [
     {file = "Pygments-2.12.0-py3-none-any.whl", hash = "sha256:dc9c10fb40944260f6ed4c688ece0cd2048414940f1cea51b8b226318411c519"},
     {file = "Pygments-2.12.0.tar.gz", hash = "sha256:5eb116118f9612ff1ee89ac96437bb6b49e8f04d8a13b514ba26f620208e26eb"},
+]
+pynvml = [
+    {file = "pynvml-11.4.1-py3-none-any.whl", hash = "sha256:d27be542cd9d06558de18e2deffc8022ccd7355bc7382255d477038e7e424c6c"},
+    {file = "pynvml-11.4.1.tar.gz", hash = "sha256:b2e4a33b80569d093b513f5804db0c7f40cfc86f15a013ae7a8e99c5e175d5dd"},
 ]
 pyparsing = [
     {file = "pyparsing-3.0.9-py3-none-any.whl", hash = "sha256:5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ tqdm = "^4.64.0"
 seqeval = "^1.2.2"
 huggingface-hub = ">=0.8.1,<1.0.0"
 datasets = "^2.4.0"
+codecarbon = "^2.1.3"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.5"

--- a/src/aiai_eval/cli.py
+++ b/src/aiai_eval/cli.py
@@ -81,14 +81,14 @@ from .task_configs import get_all_task_configs
     "-tce",
     is_flag=True,
     show_default=True,
-    help="Whether to track carbon usage.",
+    help="Whether to track carbon usage. Remember to set `--country-iso-code` to properly calculate carbon emissions",
 )
 @click.option(
     "--country-iso-code",
     "-co",
-    default="DNK",
+    default="",
     show_default=True,
-    help="The 3-letter alphabet ISO Code of the country where the compute infrastructure is hosted.",
+    help="The 3-letter alphabet ISO Code of the country where the compute infrastructure is hosted. See here: https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes",
 )
 def evaluate(
     model_id: Tuple[str],

--- a/src/aiai_eval/cli.py
+++ b/src/aiai_eval/cli.py
@@ -76,6 +76,20 @@ from .task_configs import get_all_task_configs
     show_default=True,
     help="Whether extra input should be outputted during benchmarking",
 )
+@click.option(
+    "--track-carbon-emissions",
+    "-tce",
+    is_flag=True,
+    show_default=True,
+    help="Whether to track carbon usage.",
+)
+@click.option(
+    "--country-iso-code",
+    "-co",
+    default="DNK",
+    show_default=True,
+    help="The 3-letter alphabet ISO Code of the country where the compute infrastructure is hosted.",
+)
 def evaluate(
     model_id: Tuple[str],
     task: Tuple[str],
@@ -86,6 +100,7 @@ def evaluate(
     raise_error_on_invalid_model: bool,
     cache_dir: str,
     verbose: bool = False,
+    track_carbon_emissions: bool = False,
 ):
     """Benchmark finetuned models."""
 
@@ -102,6 +117,7 @@ def evaluate(
         cache_dir=cache_dir,
         use_auth_token=auth,
         verbose=verbose,
+        track_carbon_emissions=track_carbon_emissions,
     )
 
     # Perform the benchmark evaluation

--- a/src/aiai_eval/config.py
+++ b/src/aiai_eval/config.py
@@ -139,7 +139,8 @@ class EvaluationConfig:
             Whether to track carbon usage.
         country_iso_code (str):
             The 3-letter alphabet ISO Code of the country where the compute infrastructure
-            is hosted. This is used when tracking carbon usage.
+            is hosted. This is used when tracking carbon usage. See here:
+            https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes
 
     """
 
@@ -151,7 +152,7 @@ class EvaluationConfig:
     verbose: bool
     testing: bool = False
     track_carbon_emissions: bool = False
-    country_iso_code: str = "DNK"
+    country_iso_code: str = ""
 
 
 @dataclass

--- a/src/aiai_eval/config.py
+++ b/src/aiai_eval/config.py
@@ -138,6 +138,12 @@ class EvaluationConfig:
             Whether to print verbose output.
         testing (bool, optional):
             Whether a unit test is being run. Defaults to False.
+        track_carbon_usage (bool):
+            Whether to track carbon usage.
+        country_iso_code (str):
+            The 3-letter alphabet ISO Code of the country where the compute infrastructure
+            is hosted. This is used when tracking carbon usage.
+
     """
 
     model_tasks: Optional[Sequence[str]]
@@ -149,6 +155,8 @@ class EvaluationConfig:
     save_results: bool
     verbose: bool
     testing: bool = False
+    track_carbon_emissions: bool = False
+    country_iso_code: str = "DNK"
 
 
 @dataclass

--- a/src/aiai_eval/evaluator.py
+++ b/src/aiai_eval/evaluator.py
@@ -42,6 +42,11 @@ class Evaluator:
             specified then it will be used as the token. Defaults to False.
         verbose (bool, optional):
             Whether to output additional output. Defaults to False.
+        track_carbon_emissions (bool):
+            Whether to track carbon usage.
+        country_iso_code (str):
+            The 3-letter alphabet ISO Code of the country where the compute infrastructure
+            is hosted. This is used when tracking carbon usage.
 
     Attributes:
         progress_bar (bool): Whether progress bars should be shown.
@@ -63,6 +68,8 @@ class Evaluator:
         cache_dir: str = ".aiai_eval_cache",
         use_auth_token: Union[bool, str] = False,
         verbose: bool = False,
+        track_carbon_emissions: bool = False,
+        country_iso_code: str = "DNK",
     ):
         # Build dataset tasks
         dataset_tasks = self._prepare_dataset_tasks(dataset_task)
@@ -77,6 +84,8 @@ class Evaluator:
             progress_bar=progress_bar,
             save_results=save_results,
             verbose=verbose,
+            track_carbon_emissions=track_carbon_emissions,
+            country_iso_code=country_iso_code,
         )
 
         # Initialise variable storing model lists, so we only have to fetch it once

--- a/src/aiai_eval/exceptions.py
+++ b/src/aiai_eval/exceptions.py
@@ -85,3 +85,19 @@ class UnsupportedModelType(Exception):
         self.model_type = model_type
 
         super().__init__(self.message)
+
+
+class MissingCountryISOCode(Exception):
+    def __init__(
+        self,
+        message: str = (
+            "The carbon tracker calculates carbon usage based on power consumption, "
+            "and the country where the compute infrastructure is hosted. Internet connection "
+            "was not available and hence the location of the infrastructure could not be "
+            "automatically fetched, because of the location must be set, this is done by setting "
+            "the 'country_iso_code' in the config or `--country-iso-code` via the CLI to "
+            "the correct ISO code."
+        ),
+    ):
+        self.message = message
+        super().__init__(self.message)

--- a/src/aiai_eval/hf_hub.py
+++ b/src/aiai_eval/hf_hub.py
@@ -14,6 +14,7 @@ from .exceptions import (
     ModelDoesNotExistOnHuggingFaceHubException,
     NoInternetConnection,
 )
+from .utils import internet_connection_available
 
 
 def model_exists_on_hf_hub(model_id: str) -> bool:
@@ -117,15 +118,10 @@ def get_model_config(model_id: str, evaluation_config: EvaluationConfig) -> Mode
     # If fetching from the Hugging Face Hub failed then throw a reasonable exception
     except RequestException:
 
-        # Check if it is because the internet is down, by pinging Google
-        try:
-            requests.get("https://www.google.com")
-
-            # If no errors were raised then Hugging Face Hub is down
+        # Check if it is because the internet is down
+        if internet_connection_available():
             raise HuggingFaceHubDown()
-
-        # Otherwise, if pinging Google also failed, then the internet is down
-        except RequestException:
+        else:
             raise NoInternetConnection()
 
     # Return the model config

--- a/src/aiai_eval/task.py
+++ b/src/aiai_eval/task.py
@@ -13,6 +13,7 @@ import numpy as np
 import spacy
 import torch
 import torch.nn as nn
+from codecarbon import EmissionsTracker, OfflineEmissionsTracker
 from datasets import Dataset, DatasetDict, load_dataset, load_metric
 from torch.utils.data import DataLoader
 from tqdm.auto import tqdm
@@ -35,9 +36,11 @@ from .exceptions import (
     UnsupportedModelType,
 )
 from .hf_hub import get_model_config
+from .task_configs import EMISSIONS, POWER
 from .utils import (
     clear_memory,
     enforce_reproducibility,
+    internet_connection_available,
     is_module_installed,
     log_scores,
 )
@@ -102,6 +105,10 @@ class EvaluationTask(ABC):
 
         # Load the model
         model_dict = self._load_model(model_config=model_config)
+
+        # Prepare carbon tracker
+        if self.evaluation_config.track_carbon_emissions:
+            self.carbon_tracker = self._prepare_carbon_tracker()
 
         # Load the dataset dictinoary
         dataset_dict = self._load_data()
@@ -241,10 +248,17 @@ class EvaluationTask(ABC):
 
             scores.append(test_itr_scores)
 
+        # If track_carbon_emissions is true append metrics, to correctly log emissions data.
+        # We avoid mutating, so any downstream evaluations will not try to use these.
+        metric_configs = list(self.dataset_task.metrics)
+        if self.evaluation_config.track_carbon_emissions:
+            metric_configs.append(EMISSIONS)
+            metric_configs.append(POWER)
+
         # Log scores
         all_scores = log_scores(
             dataset_name=self.dataset_task.pretty_dataset_name,
-            metric_configs=self.dataset_task.metrics,
+            metric_configs=metric_configs,
             scores=scores,
             model_id=model_config.model_id,
         )
@@ -275,6 +289,7 @@ class EvaluationTask(ABC):
                 the corresponding values.
         """
         scores = []
+        return_scores = {}
         try:
             # Set random seeds to enforce reproducibility of the randomly
             # initialised weights
@@ -300,6 +315,10 @@ class EvaluationTask(ABC):
                 test, batch_size=32, shuffle=True, collate_fn=data_collator  # type: ignore
             )
 
+            # Start carbon emissions tracking
+            if self.evaluation_config.track_carbon_emissions:
+                self.carbon_tracker.start()
+
             # Get model predictions
             for batch in dataloader:
                 if isinstance(model, PreTrainedModel):
@@ -308,12 +327,17 @@ class EvaluationTask(ABC):
                     model_predictions = model(batch)
                 else:
                     raise UnsupportedModelType(str(type(model)))
-
                 # Compute metrics
                 scores.append(compute_metrics((model_predictions, batch["labels"])))
+                break
 
-            # Aggregate scores from batches
-            return_scores = {}
+            # Stop carbon emissions tracking
+            if self.evaluation_config.track_carbon_emissions:
+                self.carbon_tracker.stop()
+                emissions_data = self.carbon_tracker.final_emissions_data
+                return_scores["carbon_emissions"] = emissions_data.emissions
+                return_scores["energy_consumed"] = emissions_data.energy_consumed
+
             for metric in self.dataset_task.metrics:
                 if len(scores):
                     return_scores[metric.name] = np.average(
@@ -648,6 +672,55 @@ class EvaluationTask(ABC):
         """
         # TODO: Only a placeholder for now
         return model
+
+    def _prepare_carbon_tracker(
+        self,
+    ) -> Union[EmissionsTracker, OfflineEmissionsTracker]:
+        """Prepares a carbon emissions tracker.
+
+        Returns:
+            EmissionsTracker or OfflineEmissionsTracker:
+                A carbon emissions tracker. OfflineEmissionsTracker is returned if no internet
+                connection is available.
+        """
+        tracker_name = self.dataset_task.dataset_name
+        if self.evaluation_config.verbose:
+            log_level = "info"
+        else:
+            log_level = "error"
+
+        if internet_connection_available():
+            carbon_tracker = EmissionsTracker(
+                project_name=tracker_name,
+                measure_power_secs=5,
+                save_to_file=False,
+                save_to_api=False,
+                save_to_logger=False,
+                log_level=log_level,
+            )
+        else:
+            # If country_iso_code is "DNK", send warning
+            country_iso_code = self.evaluation_config.country_iso_code
+            if country_iso_code == "DNK":
+                message = (
+                    "The carbon tracker calculates carbon usage based on power consumption, "
+                    "and the country where the compute infrastructure is hosted. Internet connection "
+                    "was not available and hence the location of the infrastructure could not be "
+                    "automatically fetched, because of the this the location defaults to 'DNK'."
+                    "If the compute infrastructure is not hosted in Denmark, change the"
+                    "'country_iso_code' to the correct ISO code."
+                )
+                warnings.warn(message)
+            carbon_tracker = OfflineEmissionsTracker(
+                project_name=tracker_name,
+                measure_power_secs=5,
+                save_to_file=False,
+                save_to_api=False,
+                save_to_logger=False,
+                country_iso_code=country_iso_code,
+                log_level=log_level,
+            )
+        return carbon_tracker
 
     @abstractmethod
     def _preprocess_data_pytorch(

--- a/src/aiai_eval/task.py
+++ b/src/aiai_eval/task.py
@@ -31,6 +31,7 @@ from .config import EvaluationConfig, ModelConfig, TaskConfig
 from .exceptions import (
     InvalidEvaluation,
     InvalidFramework,
+    MissingCountryISOCode,
     ModelFetchFailed,
     PreprocessingFailed,
     UnsupportedModelType,
@@ -690,18 +691,11 @@ class Task(ABC):
                 log_level=log_level,
             )
         else:
-            # If country_iso_code is "DNK", send warning
+            # If country_iso_code is "", raise exception
             country_iso_code = self.evaluation_config.country_iso_code
-            if country_iso_code == "DNK":
-                message = (
-                    "The carbon tracker calculates carbon usage based on power consumption, "
-                    "and the country where the compute infrastructure is hosted. Internet connection "
-                    "was not available and hence the location of the infrastructure could not be "
-                    "automatically fetched, because of the this the location defaults to 'DNK'."
-                    "If the compute infrastructure is not hosted in Denmark, change the"
-                    "'country_iso_code' to the correct ISO code."
-                )
-                warnings.warn(message)
+            if country_iso_code == "":
+                raise MissingCountryISOCode
+
             carbon_tracker = OfflineEmissionsTracker(
                 project_name=tracker_name,
                 measure_power_secs=5,

--- a/src/aiai_eval/task.py
+++ b/src/aiai_eval/task.py
@@ -321,7 +321,6 @@ class Task(ABC):
                     raise UnsupportedModelType(str(type(model)))
                 # Compute metrics
                 scores.append(compute_metrics((model_predictions, batch["labels"])))
-                break
 
             # Stop carbon emissions tracking
             if self.evaluation_config.track_carbon_emissions:

--- a/src/aiai_eval/task_configs.py
+++ b/src/aiai_eval/task_configs.py
@@ -200,3 +200,18 @@ SENT = DatasetTask(
     ],
     split_names={"train": "train", "test": "test", "val": None},
 )
+
+
+EMISSIONS = MetricConfig(
+    name="carbon_emissions",
+    pretty_name="Carbon Emissions",
+    huggingface_id="",
+    results_key="co2",
+)
+
+POWER = MetricConfig(
+    name="energy_consumed",
+    pretty_name="Energy Consumed",
+    huggingface_id="",
+    results_key="power",
+)

--- a/src/aiai_eval/text_classification.py
+++ b/src/aiai_eval/text_classification.py
@@ -60,7 +60,7 @@ class TextClassification(Task):
 
         # Translate labels to ids
         numericalise = partial(
-            self._create_numerical_labels, label2id=kwargs["dataset_task"].label2id
+            self._create_numerical_labels, label2id=kwargs["task_config"].label2id
         )
         preprocessed = tokenised.map(
             numericalise, batched=True, load_from_cache_file=False

--- a/src/aiai_eval/utils.py
+++ b/src/aiai_eval/utils.py
@@ -168,7 +168,6 @@ def aggregate_scores(
 
 def internet_connection_available() -> bool:
     try:
-        # Check if internet connection is available.
         requests.get("https://www.google.com")
         return True
     except RequestException:

--- a/src/aiai_eval/utils.py
+++ b/src/aiai_eval/utils.py
@@ -10,7 +10,9 @@ from typing import Dict, Sequence, Tuple
 
 import numpy as np
 import pkg_resources
+import requests
 import torch
+from requests import RequestException
 
 from .config import MetricConfig
 
@@ -164,3 +166,12 @@ def aggregate_scores(
         results["test"] = (test_score, 1.96 * test_se)
 
         return results
+
+
+def internet_connection_available() -> bool:
+    try:
+        # Check if internet connection is available.
+        requests.get("https://www.google.com")
+        return True
+    except RequestException:
+        return False

--- a/src/aiai_eval/utils.py
+++ b/src/aiai_eval/utils.py
@@ -116,8 +116,6 @@ def log_scores(
     for metric_cfg in metric_configs:
         agg_scores = aggregate_scores(scores=scores, metric_config=metric_cfg)
         test_score, test_se = agg_scores["test"]
-        test_score *= 100
-        test_se *= 100
 
         msg = f"{metric_cfg.pretty_name}:\n  - Test: {test_score:.2f} ± {test_se:.2f}"
 

--- a/src/aiai_eval/utils.py
+++ b/src/aiai_eval/utils.py
@@ -167,6 +167,11 @@ def aggregate_scores(
 
 
 def internet_connection_available() -> bool:
+    """Checks if internet connection is available by pinging google.com.
+
+    Returns:
+            bool: whether or not internet connection is available.
+    """
     try:
         requests.get("https://www.google.com")
         return True

--- a/src/aiai_eval/utils.py
+++ b/src/aiai_eval/utils.py
@@ -117,7 +117,7 @@ def log_scores(
         agg_scores = aggregate_scores(scores=scores, metric_config=metric_cfg)
         test_score, test_se = agg_scores["test"]
 
-        msg = f"{metric_cfg.pretty_name}:\n  - Test: {test_score:.2f} ± {test_se:.2f}"
+        msg = f"{metric_cfg.pretty_name}:\n  - Test: {test_score:.4f} ± {test_se:.4f}"
 
         # Store the aggregated test scores
         total_dict[metric_cfg.name] = test_score


### PR DESCRIPTION
This PR introduces:

- `codecarbon` usage.
- metric configs corresponding to `carbon_emissions` and `energy_consumed` (`EMISSIONS` and `POWER` resp.) are added to `task_configs.py`. **We should consider creating `metric_configs.py` no?**
- function for checking if internet connection is available.

Ill briefly describe how the carbon emission tracking works:

1. During the preparation of the tracker, internet availability is checked. The tracker is instantiated in either online or offline mode.
2. The tracker is started just before the loop over the dataloader and is stopped immediately after.
3. The `carbon_emissions` and `energy_consumed` for the iteration are stored.
4. Before logging a copy of `self.task_config.metrics` is created and the metrics `EMISSIONS` and `POWER` are appended to ensure:
    * The logging is done in the same way across all metrics, independent of when they are calculated,
    * The `self.task_config.metrics` is not mutated, so in case of multiple `model_ids` the metrics `EMISSIONS` and `POWER` will not be used in `_compute_metrics` and cause errors.

It might be that the copying of `self.task_config.metrics` is unnecessary, i need to investigate further.