### PR TITLE
Add `co2` and `country_codes` modules

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,12 +30,6 @@ jobs:
         with:
           poetry-version: 1.1.14
 
-      - name: Set Poetry config
-        run: |
-          poetry config virtualenvs.create true
-          poetry config virtualenvs.in-project false
-          poetry config virtualenvs.path ~/.virtualenvs
-
       - name: Set up Python
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,17 +23,17 @@ jobs:
             python-version: ['3.8', '3.9', '3.10']
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Install Poetry
         uses: abatilo/actions-poetry@v2.0.0
         with:
-          poetry-version: 1.1.10
+          poetry-version: 1.1.14
 
       - name: Set Poetry config
         run: |
@@ -42,7 +42,7 @@ jobs:
           poetry config virtualenvs.path ~/.virtualenvs
 
       - name: Cache Poetry virtualenv
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         id: cache
         with:
           path: ~/.virtualenvs

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,7 +38,6 @@ jobs:
 
       - name: Install Dependencies
         run: poetry install
-        if: steps.cache.outputs.cache-hit != 'true'
 
       - name: Test with pytest
         run: poetry run pytest -n 1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,9 +26,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install Poetry
-        uses: abatilo/actions-poetry@v2.0.0
-        with:
-          poetry-version: 1.1.10
+        run: pipx install poetry==1.1.0
 
       - name: Set up Python
         uses: actions/setup-python@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,24 +20,26 @@ jobs:
     strategy:
         matrix:
             os: [windows-latest, macos-latest, ubuntu-latest]
-            python-version: ['3.8', '3.9', '3.10']
+            python-version: ["3.8", "3.9", "3.10"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: "poetry"
 
       - name: Install Poetry
         uses: abatilo/actions-poetry@v2.0.0
         with:
           poetry-version: 1.1.10
 
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-          cache: 'poetry'
-
       - name: Install Dependencies
-        run: poetry install
+        run: |
+          poetry env use "${{ matrix.python-version }}"
+          poetry install
 
       - name: Test with pytest
         run: poetry run pytest -n 1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,16 +25,16 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Install Poetry
+        uses: abatilo/actions-poetry@v2.0.0
+        with:
+          poetry-version: 1.1.10
+
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
           cache: "poetry"
-
-      - name: Install Poetry
-        uses: abatilo/actions-poetry@v2.0.0
-        with:
-          poetry-version: 1.1.10
 
       - name: Install Dependencies
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,12 +25,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-          cache: 'poetry'
-
       - name: Install Poetry
         uses: abatilo/actions-poetry@v2.0.0
         with:
@@ -41,6 +35,12 @@ jobs:
           poetry config virtualenvs.create true
           poetry config virtualenvs.in-project false
           poetry config virtualenvs.path ~/.virtualenvs
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'poetry'
 
       - name: Install Dependencies
         run: poetry install

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: Install Poetry
         uses: abatilo/actions-poetry@v2.0.0
         with:
-          poetry-version: 1.1.14
+          poetry-version: 1.1.10
 
       - name: Set up Python
         uses: actions/setup-python@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,6 +29,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'poetry'
 
       - name: Install Poetry
         uses: abatilo/actions-poetry@v2.0.0
@@ -40,15 +41,6 @@ jobs:
           poetry config virtualenvs.create true
           poetry config virtualenvs.in-project false
           poetry config virtualenvs.path ~/.virtualenvs
-
-      - name: Cache Poetry virtualenv
-        uses: actions/cache@v3
-        id: cache
-        with:
-          path: ~/.virtualenvs
-          key: poetry-${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('**/poetry.lock') }}
-          restore-keys: |
-            poetry-${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('**/poetry.lock') }}
 
       - name: Install Dependencies
         run: poetry install

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -21,6 +21,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'poetry'
 
       - name: Install Poetry
         uses: abatilo/actions-poetry@v2.0.0
@@ -32,15 +33,6 @@ jobs:
           poetry config virtualenvs.create true
           poetry config virtualenvs.in-project false
           poetry config virtualenvs.path ~/.virtualenvs
-
-      - name: Cache Poetry virtualenv
-        uses: actions/cache@v3
-        id: cache
-        with:
-          path: ~/.virtualenvs
-          key: poetry-${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('**/poetry.lock') }}
-          restore-keys: |
-            poetry-${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('**/poetry.lock') }}
 
       - name: Install Dependencies
         run: poetry install

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -17,12 +17,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-          cache: 'poetry'
-
       - name: Install Poetry
         uses: abatilo/actions-poetry@v2.0.0
         with:
@@ -33,6 +27,12 @@ jobs:
           poetry config virtualenvs.create true
           poetry config virtualenvs.in-project false
           poetry config virtualenvs.path ~/.virtualenvs
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'poetry'
 
       - name: Install Dependencies
         run: poetry install

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -25,14 +25,16 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python-version }}
-          cache: 'poetry'
+          python-version: "3.10"
+          cache: "poetry"
 
       - name: Install Dependencies
         run: poetry install
 
       - name: Build documentation
-        run: poetry run pdoc --docformat google src/aiai_eval -o docs
+        run: |
+          poetry env use "3.10"
+          poetry run pdoc --docformat google src/aiai_eval -o docs
 
       - name: Compress documentation
         run: tar --directory docs/ -hcf artifact.tar .

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Install Poetry
         uses: abatilo/actions-poetry@v2.0.0
         with:
-          poetry-version: 1.1.14
+          poetry-version: 1.1.10
 
       - name: Set up Python
         uses: actions/setup-python@v4

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -30,7 +30,6 @@ jobs:
 
       - name: Install Dependencies
         run: poetry install
-        if: steps.cache.outputs.cache-hit != 'true'
 
       - name: Build documentation
         run: poetry run pdoc --docformat google src/aiai_eval -o docs

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -22,12 +22,6 @@ jobs:
         with:
           poetry-version: 1.1.14
 
-      - name: Set Poetry config
-        run: |
-          poetry config virtualenvs.create true
-          poetry config virtualenvs.in-project false
-          poetry config virtualenvs.path ~/.virtualenvs
-
       - name: Set up Python
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -18,9 +18,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install Poetry
-        uses: abatilo/actions-poetry@v2.0.0
-        with:
-          poetry-version: 1.1.10
+        run: pipx install poetry==1.1.0
 
       - name: Set up Python
         uses: actions/setup-python@v4

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -15,17 +15,17 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Install Poetry
         uses: abatilo/actions-poetry@v2.0.0
         with:
-          poetry-version: 1.1.10
+          poetry-version: 1.1.14
 
       - name: Set Poetry config
         run: |
@@ -34,7 +34,7 @@ jobs:
           poetry config virtualenvs.path ~/.virtualenvs
 
       - name: Cache Poetry virtualenv
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         id: cache
         with:
           path: ~/.virtualenvs

--- a/README.md
+++ b/README.md
@@ -80,8 +80,9 @@ models and/or datasets:
 ├── .pre-commit-config.yaml
 ├── LICENSE
 ├── README.md
+├── aiai_evaluation_results.json
 ├── gfx
-│   └── logo.png
+│   └── aiai-eval-logo.png
 ├── makefile
 ├── models
 ├── notebooks
@@ -92,13 +93,16 @@ models and/or datasets:
 │   │   ├── __init__.py
 │   │   ├── automatic_speech_recognition.py
 │   │   ├── cli.py
+│   │   ├── co2.py
 │   │   ├── config.py
+│   │   ├── country_codes.py
 │   │   ├── evaluator.py
 │   │   ├── exceptions.py
 │   │   ├── hf_hub.py
 │   │   ├── image_to_text.py
 │   │   ├── named_entity_recognition.py
 │   │   ├── question_answering.py
+│   │   ├── scoring.py
 │   │   ├── task.py
 │   │   ├── task_configs.py
 │   │   ├── task_factory.py
@@ -108,5 +112,22 @@ models and/or datasets:
 │       ├── fix_dot_env_file.py
 │       └── versioning.py
 └── tests
-    └── __init__.py
+    ├── __init__.py
+    ├── conftest.py
+    ├── test_cli.py
+    ├── test_co2.py
+    ├── test_config.py
+    ├── test_country_codes.py
+    ├── test_evaluator.py
+    ├── test_exceptions.py
+    ├── test_hf_hub.py
+    ├── test_image_to_text.py
+    ├── test_named_entity_recognition.py
+    ├── test_question_answering.py
+    ├── test_scoring.py
+    ├── test_task.py
+    ├── test_task_configs.py
+    ├── test_task_factory.py
+    ├── test_text_classification.py
+    └── test_utils.py
 ```

--- a/README.md
+++ b/README.md
@@ -80,7 +80,6 @@ models and/or datasets:
 ├── .pre-commit-config.yaml
 ├── LICENSE
 ├── README.md
-├── aiai_evaluation_results.json
 ├── gfx
 │   └── aiai-eval-logo.png
 ├── makefile

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ ______________________________________________________________________
 [![Documentation](https://img.shields.io/badge/docs-passing-green)](https://alexandrainst.github.io/AIAI-eval/aiai_eval.html)
 [![License](https://img.shields.io/github/license/alexandrainst/AIAI-eval)](https://github.com/alexandrainst/AIAI-eval/blob/main/LICENSE)
 [![LastCommit](https://img.shields.io/github/last-commit/alexandrainst/AIAI-eval)](https://github.com/alexandrainst/AIAI-eval/commits/main)
-[![Code Coverage](https://img.shields.io/badge/Coverage-51%25-orange.svg)](https://github.com/alexandrainst/AIAI-eval/tree/dev/tests)
+[![Code Coverage](https://img.shields.io/badge/Coverage-52%25-orange.svg)](https://github.com/alexandrainst/AIAI-eval/tree/dev/tests)
 
 
 Developers:

--- a/makefile
+++ b/makefile
@@ -109,4 +109,5 @@ tree:
 		-I *.txt \
 		-I checkpoint-* \
 		-I .coverage* \
-		-I .aiai_cache
+		-I .aiai_cache \
+		-I aiai_evaluation_results.json

--- a/makefile
+++ b/makefile
@@ -108,4 +108,5 @@ tree:
 		-I *.csv \
 		-I *.txt \
 		-I checkpoint-* \
-		-I .coverage*
+		-I .coverage* \
+		-I .aiai_cache

--- a/poetry.lock
+++ b/poetry.lock
@@ -237,13 +237,13 @@ xxhash = "*"
 [package.extras]
 vision = ["Pillow (>=6.2.1)"]
 torch = ["torch"]
-tests = ["importlib-resources", "librosa", "Pillow (>=6.2.1)", "six (>=1.15.0,<1.16.0)", "Werkzeug (>=1.0.1)", "texttable (>=1.6.3)", "tldextract (>=3.1.0)", "requests-file (>=1.5.1)", "toml (>=0.10.1)", "seqeval", "scipy", "scikit-learn", "sacrebleu", "rouge-score (<0.0.7)", "mauve-text", "jiwer", "bert-score (>=0.3.6)", "sacremoses", "sentencepiece", "zstandard", "tldextract", "py7zr", "openpyxl", "nltk", "mwparserfromhell", "lz4", "lxml", "langdetect", "h5py", "conllu", "bs4", "transformers", "soundfile", "torchaudio", "torch", "tensorflow (>=2.3,!=2.6.0,!=2.6.1)", "s3fs (>=2021.11.1)", "rarfile (>=4.0)", "moto[s3,server] (==2.0.4)", "fsspec", "faiss-cpu (>=1.6.4)", "botocore (>=1.22.8)", "boto3 (>=1.19.8)", "aiobotocore (>=2.0.1)", "elasticsearch (<8.0.0)", "apache-beam (>=2.26.0)", "pytest-xdist", "pytest-datadir", "pytest", "absl-py"]
+tests = ["importlib-resources", "librosa", "Pillow (>=6.2.1)", "six (>=1.15.0,<1.16.0)", "Werkzeug (>=1.0.1)", "texttable (>=1.6.3)", "tldextract (>=3.1.0)", "requests-file (>=1.5.1)", "toml (>=0.10.1)", "seqeval", "scipy", "scikit-learn", "sacrebleu", "rouge-score (<0.0.7)", "mauve-text", "jiwer", "bert-score (>=0.3.6)", "sacremoses", "sentencepiece", "zstandard", "tldextract", "py7zr", "openpyxl", "nltk", "mwparserfromhell", "lz4", "lxml", "langdetect", "h5py", "conllu", "bs4", "transformers", "soundfile", "torchaudio", "torch", "tensorflow (>=2.3,!=2.6.0,!=2.6.1)", "s3fs (>=2021.11.1)", "rarfile (>=4.0)", "moto[server,s3] (==2.0.4)", "fsspec", "faiss-cpu (>=1.6.4)", "botocore (>=1.22.8)", "boto3 (>=1.19.8)", "aiobotocore (>=2.0.1)", "elasticsearch (<8.0.0)", "apache-beam (>=2.26.0)", "pytest-xdist", "pytest-datadir", "pytest", "absl-py"]
 tensorflow_gpu = ["tensorflow-gpu (>=2.2.0,!=2.6.0,!=2.6.1)"]
 tensorflow = ["tensorflow (>=2.2.0,!=2.6.0,!=2.6.1)"]
 s3 = ["s3fs", "botocore", "boto3", "fsspec"]
 quality = ["pyyaml (>=5.3.1)", "isort (>=5.0.0)", "flake8 (>=3.8.3)", "black (>=22.0,<23.0)"]
 docs = ["s3fs"]
-dev = ["importlib-resources", "pyyaml (>=5.3.1)", "isort (>=5.0.0)", "flake8 (>=3.8.3)", "black (>=22.0,<23.0)", "librosa", "Pillow (>=6.2.1)", "six (>=1.15.0,<1.16.0)", "Werkzeug (>=1.0.1)", "texttable (>=1.6.3)", "tldextract (>=3.1.0)", "requests-file (>=1.5.1)", "toml (>=0.10.1)", "seqeval", "scipy", "scikit-learn", "sacrebleu", "rouge-score (<0.0.7)", "mauve-text", "jiwer", "bert-score (>=0.3.6)", "sacremoses", "sentencepiece", "zstandard", "tldextract", "py7zr", "openpyxl", "nltk", "mwparserfromhell", "lz4", "lxml", "langdetect", "h5py", "conllu", "bs4", "transformers", "soundfile", "torchaudio", "torch", "tensorflow (>=2.3,!=2.6.0,!=2.6.1)", "s3fs (>=2021.11.1)", "rarfile (>=4.0)", "moto[s3,server] (==2.0.4)", "fsspec", "faiss-cpu (>=1.6.4)", "botocore (>=1.22.8)", "boto3 (>=1.19.8)", "aiobotocore (>=2.0.1)", "elasticsearch (<8.0.0)", "apache-beam (>=2.26.0)", "pytest-xdist", "pytest-datadir", "pytest", "absl-py"]
+dev = ["importlib-resources", "pyyaml (>=5.3.1)", "isort (>=5.0.0)", "flake8 (>=3.8.3)", "black (>=22.0,<23.0)", "librosa", "Pillow (>=6.2.1)", "six (>=1.15.0,<1.16.0)", "Werkzeug (>=1.0.1)", "texttable (>=1.6.3)", "tldextract (>=3.1.0)", "requests-file (>=1.5.1)", "toml (>=0.10.1)", "seqeval", "scipy", "scikit-learn", "sacrebleu", "rouge-score (<0.0.7)", "mauve-text", "jiwer", "bert-score (>=0.3.6)", "sacremoses", "sentencepiece", "zstandard", "tldextract", "py7zr", "openpyxl", "nltk", "mwparserfromhell", "lz4", "lxml", "langdetect", "h5py", "conllu", "bs4", "transformers", "soundfile", "torchaudio", "torch", "tensorflow (>=2.3,!=2.6.0,!=2.6.1)", "s3fs (>=2021.11.1)", "rarfile (>=4.0)", "moto[server,s3] (==2.0.4)", "fsspec", "faiss-cpu (>=1.6.4)", "botocore (>=1.22.8)", "boto3 (>=1.19.8)", "aiobotocore (>=2.0.1)", "elasticsearch (<8.0.0)", "apache-beam (>=2.26.0)", "pytest-xdist", "pytest-datadir", "pytest", "absl-py"]
 benchmarks = ["transformers (==3.0.2)", "torch (==1.6.0)", "tensorflow (==2.3.0)", "numpy (==1.18.5)"]
 audio = ["librosa"]
 apache-beam = ["apache-beam (>=2.26.0)"]
@@ -1275,7 +1275,7 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8,<3.11"
-content-hash = "cd6161e7d67633a0048873157c6cd537e7879d0fb1d3bec95f65bc30a01a6447"
+content-hash = "98ac30bfced72f686b98087300d5a45f73ca4084f8166348dd9126a37da2fcef"
 
 [metadata.files]
 aiohttp = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ seqeval = "^1.2.2"
 huggingface-hub = ">=0.8.1,<1.0.0"
 datasets = "^2.4.0"
 codecarbon = "^2.1.3"
+fsspec = "^2022.7.1"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.5"

--- a/src/aiai_eval/cli.py
+++ b/src/aiai_eval/cli.py
@@ -46,16 +46,16 @@ from .task_configs import get_all_task_configs
     "-co2",
     is_flag=True,
     show_default=True,
-    help="""Whether to track carbon usage. Remember to set `--country-iso-code` to
-    properly calculate carbon emissions""",
+    help="""Whether to track carbon usage.""",
 )
 @click.option(
     "--country-iso-code",
-    "-co",
+    "-c",
     default="",
     show_default=True,
     help="""The 3-letter alphabet ISO Code of the country where the compute
-    infrastructure is hosted. See here:
+    infrastructure is hosted. Only relevant if no internet connection is available. A
+    list of all such codes are available here:
     https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes""",
 )
 @click.option(
@@ -81,7 +81,6 @@ from .task_configs import get_all_task_configs
 )
 @click.option(
     "--cache-dir",
-    "-c",
     default=".aiai_cache",
     show_default=True,
     help="The directory where models are datasets are cached.",

--- a/src/aiai_eval/cli.py
+++ b/src/aiai_eval/cli.py
@@ -58,13 +58,6 @@ from .task_configs import get_all_task_configs
     available here: https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes""",
 )
 @click.option(
-    "--measure-power-secs",
-    default=5,
-    show_default=True,
-    help="""How often power is measured, in seconds. Only relevant if
-    `--track-carbon-emissions` is set to True.""",
-)
-@click.option(
     "--no-progress-bar",
     "-np",
     is_flag=True,
@@ -105,7 +98,6 @@ def evaluate(
     use_auth_token: bool,
     track_carbon_emissions: bool,
     country_iso_code: str,
-    measure_power_secs: int,
     no_progress_bar: bool,
     no_save_results: bool,
     raise_error_on_invalid_model: bool,
@@ -135,7 +127,6 @@ def evaluate(
         verbose=verbose,
         track_carbon_emissions=track_carbon_emissions,
         country_iso_code=country_iso_code,
-        measure_power_secs=measure_power_secs,
     )
 
     # Perform the benchmark evaluation

--- a/src/aiai_eval/cli.py
+++ b/src/aiai_eval/cli.py
@@ -50,13 +50,19 @@ from .task_configs import get_all_task_configs
 )
 @click.option(
     "--country-iso-code",
-    "-c",
     default="",
     show_default=True,
     help="""The 3-letter alphabet ISO Code of the country where the compute
-    infrastructure is hosted. Only relevant if no internet connection is available. A
-    list of all such codes are available here:
-    https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes""",
+    infrastructure is hosted. Only relevant if no internet connection is available.
+    Only relevant if `--track-carbon-emissions` is set. A list of all such codes are
+    available here: https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes""",
+)
+@click.option(
+    "--measure-power-secs",
+    default=5,
+    show_default=True,
+    help="""How often power is measured, in seconds. Only relevant if
+    `--track-carbon-emissions` is set to True.""",
 )
 @click.option(
     "--no-progress-bar",
@@ -99,6 +105,7 @@ def evaluate(
     use_auth_token: bool,
     track_carbon_emissions: bool,
     country_iso_code: str,
+    measure_power_secs: int,
     no_progress_bar: bool,
     no_save_results: bool,
     raise_error_on_invalid_model: bool,
@@ -128,6 +135,7 @@ def evaluate(
         verbose=verbose,
         track_carbon_emissions=track_carbon_emissions,
         country_iso_code=country_iso_code,
+        measure_power_secs=measure_power_secs,
     )
 
     # Perform the benchmark evaluation

--- a/src/aiai_eval/cli.py
+++ b/src/aiai_eval/cli.py
@@ -43,7 +43,7 @@ from .task_configs import get_all_task_configs
 )
 @click.option(
     "--track-carbon-emissions",
-    "-tce",
+    "-co2",
     is_flag=True,
     show_default=True,
     help="""Whether to track carbon usage. Remember to set `--country-iso-code` to

--- a/src/aiai_eval/cli.py
+++ b/src/aiai_eval/cli.py
@@ -51,7 +51,7 @@ from .task_configs import get_all_task_configs
 )
 @click.option(
     "--country-iso-code",
-    type=click.Choice(ALL_COUNTRY_CODES),
+    type=click.Choice([""] + ALL_COUNTRY_CODES),
     default="",
     show_default=True,
     metavar="ISO 3166-1 ALPHA-3 LANGUAGE CODE",

--- a/src/aiai_eval/cli.py
+++ b/src/aiai_eval/cli.py
@@ -4,6 +4,7 @@ from typing import Tuple, Union
 
 import click
 
+from .country_codes import ALL_COUNTRY_CODES
 from .evaluator import Evaluator
 from .task_configs import get_all_task_configs
 
@@ -50,8 +51,10 @@ from .task_configs import get_all_task_configs
 )
 @click.option(
     "--country-iso-code",
+    type=click.Choice(ALL_COUNTRY_CODES),
     default="",
     show_default=True,
+    metavar="ISO 3166-1 ALPHA-3 LANGUAGE CODE",
     help="""The 3-letter alphabet ISO Code of the country where the compute
     infrastructure is hosted. Only relevant if no internet connection is available.
     Only relevant if `--track-carbon-emissions` is set. A list of all such codes are

--- a/src/aiai_eval/co2.py
+++ b/src/aiai_eval/co2.py
@@ -1,0 +1,58 @@
+"""Functions related to carbon emission measurement."""
+
+from typing import Union
+
+from codecarbon import EmissionsTracker, OfflineEmissionsTracker
+
+from .exceptions import MissingCountryISOCode
+from .utils import internet_connection_available
+
+
+def get_carbon_tracker(
+    task_name: str, country_iso_code: str, measure_power_secs: int, verbose: bool
+) -> Union[EmissionsTracker, OfflineEmissionsTracker]:
+    """Prepares a carbon emissions tracker.
+
+    Args:
+        task_name (str):
+            Name of the task.
+        country_iso_code (str):
+            ISO code of the country. Only relevant if no internet connection is
+            available. A list of all such codes are available here:
+            https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes
+        measure_power_secs (int):
+            How often power is measured, in seconds.
+        verbose (bool):
+            Whether to print verbose output.
+
+    Returns:
+        EmissionsTracker or OfflineEmissionsTracker:
+            A carbon emissions tracker. OfflineEmissionsTracker is returned if no
+            internet connection is available.
+    """
+    log_level = "info" if verbose else "error"
+
+    if internet_connection_available():
+        carbon_tracker = EmissionsTracker(
+            project_name=task_name,
+            measure_power_secs=measure_power_secs,
+            log_level=log_level,
+            save_to_file=False,
+            save_to_api=False,
+            save_to_logger=False,
+        )
+    else:
+        # If country_iso_code is "", raise exception
+        if country_iso_code == "":
+            raise MissingCountryISOCode
+
+        carbon_tracker = OfflineEmissionsTracker(
+            project_name=task_name,
+            measure_power_secs=measure_power_secs,
+            country_iso_code=country_iso_code,
+            log_level=log_level,
+            save_to_file=False,
+            save_to_api=False,
+            save_to_logger=False,
+        )
+    return carbon_tracker

--- a/src/aiai_eval/co2.py
+++ b/src/aiai_eval/co2.py
@@ -9,7 +9,7 @@ from .utils import internet_connection_available
 
 
 def get_carbon_tracker(
-    task_name: str, country_iso_code: str, measure_power_secs: int, verbose: bool
+    task_name: str, country_iso_code: str, verbose: bool
 ) -> Union[EmissionsTracker, OfflineEmissionsTracker]:
     """Prepares a carbon emissions tracker.
 
@@ -20,8 +20,6 @@ def get_carbon_tracker(
             ISO code of the country. Only relevant if no internet connection is
             available. A list of all such codes are available here:
             https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes
-        measure_power_secs (int):
-            How often power is measured, in seconds.
         verbose (bool):
             Whether to print verbose output.
 
@@ -35,7 +33,7 @@ def get_carbon_tracker(
     if internet_connection_available():
         carbon_tracker = EmissionsTracker(
             project_name=task_name,
-            measure_power_secs=measure_power_secs,
+            measure_power_secs=1,
             log_level=log_level,
             save_to_file=False,
             save_to_api=False,
@@ -48,7 +46,7 @@ def get_carbon_tracker(
 
         carbon_tracker = OfflineEmissionsTracker(
             project_name=task_name,
-            measure_power_secs=measure_power_secs,
+            measure_power_secs=1,
             country_iso_code=country_iso_code,
             log_level=log_level,
             save_to_file=False,

--- a/src/aiai_eval/config.py
+++ b/src/aiai_eval/config.py
@@ -137,15 +137,19 @@ class EvaluationConfig:
             'evaluation_results.json'.
         verbose (bool):
             Whether to print verbose output.
-        testing (bool, optional):
-            Whether a unit test is being run. Defaults to False.
         track_carbon_usage (bool):
             Whether to track carbon usage.
         country_iso_code (str):
-            The 3-letter alphabet ISO Code of the country where the compute infrastructure
-            is hosted. This is used when tracking carbon usage. See here:
+            The 3-letter alphabet ISO Code of the country where the compute
+            infrastructure is hosted. Only relevant if no internet connection is
+            available. Only relevant if `track_carbon_emissions` is set to True. A list
+            of all such codes are available here:
             https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes
-
+        measure_power_secs (int):
+            How often power is measured, in seconds. Only relevant if
+            `track_carbon_emissions` is set to True.
+        testing (bool, optional):
+            Whether a unit test is being run. Defaults to False.
     """
 
     raise_error_on_invalid_model: bool
@@ -154,9 +158,10 @@ class EvaluationConfig:
     progress_bar: bool
     save_results: bool
     verbose: bool
+    track_carbon_emissions: bool
+    country_iso_code: str
+    measure_power_secs: int
     testing: bool = False
-    track_carbon_emissions: bool = False
-    country_iso_code: str = ""
 
 
 @dataclass

--- a/src/aiai_eval/config.py
+++ b/src/aiai_eval/config.py
@@ -145,9 +145,6 @@ class EvaluationConfig:
             available. Only relevant if `track_carbon_emissions` is set to True. A list
             of all such codes are available here:
             https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes
-        measure_power_secs (int):
-            How often power is measured, in seconds. Only relevant if
-            `track_carbon_emissions` is set to True.
         testing (bool, optional):
             Whether a unit test is being run. Defaults to False.
     """
@@ -160,7 +157,6 @@ class EvaluationConfig:
     verbose: bool
     track_carbon_emissions: bool
     country_iso_code: str
-    measure_power_secs: int
     testing: bool = False
 
 

--- a/src/aiai_eval/country_codes.py
+++ b/src/aiai_eval/country_codes.py
@@ -1,0 +1,258 @@
+"""All ISO 3166-1 alpha-3 country codes.
+
+Fetched from https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3.
+
+Last updated on August 17, 2022.
+"""
+
+ALL_COUNTRY_CODES = [
+    "ABW",  # Aruba
+    "AFG",  # Afghanistan
+    "AGO",  # Angola
+    "AIA",  # Anguilla
+    "ALA",  # Aaland Islands
+    "ALB",  # Albania
+    "AND",  # Andorra
+    "ARE",  # United Arab Emirates
+    "ARG",  # Argentina
+    "ARM",  # Armenia
+    "ASM",  # American Samoa
+    "ATA",  # Antarctica
+    "ATF",  # French Southern Territories
+    "ATG",  # Antigua and Barbuda
+    "AUS",  # Australia
+    "AUT",  # Austria
+    "AZE",  # Azerbaijan
+    "BDI",  # Burundi
+    "BEL",  # Belgium
+    "BEN",  # Benin
+    "BES",  # Bonaire, Sint Eustatius and Saba
+    "BFA",  # Burkina Faso
+    "BGD",  # Bangladesh
+    "BGR",  # Bulgaria
+    "BHR",  # Bahrain
+    "BHS",  # Bahamas
+    "BIH",  # Bosnia and Herzegovina
+    "BLM",  # Saint Barthelemy
+    "BLR",  # Belarus
+    "BLZ",  # Belize
+    "BMU",  # Bermuda
+    "BOL",  # Bolivia (Plurinational State of)
+    "BRA",  # Brazil
+    "BRB",  # Barbados
+    "BRN",  # Brunei Darussalam
+    "BTN",  # Bhutan
+    "BVT",  # Bouvet Island
+    "BWA",  # Botswana
+    "CAF",  # Central African Republic
+    "CAN",  # Canada
+    "CCK",  # Cocos (Keeling) Islands
+    "CHE",  # Switzerland
+    "CHL",  # Chile
+    "CHN",  # China
+    "CIV",  # Cote d'Ivoire
+    "CMR",  # Cameroon
+    "COD",  # Congo, Democratic Republic of the
+    "COG",  # Congo
+    "COK",  # Cook Islands
+    "COL",  # Colombia
+    "COM",  # Comoros
+    "CPV",  # Cabo Verde
+    "CRI",  # Costa Rica
+    "CUB",  # Cuba
+    "CUW",  # Curacao
+    "CXR",  # Christmas Island
+    "CYM",  # Cayman Islands
+    "CYP",  # Cyprus
+    "CZE",  # Czechia
+    "DEU",  # Germany
+    "DJI",  # Djibouti
+    "DMA",  # Dominica
+    "DNK",  # Denmark
+    "DOM",  # Dominican Republic
+    "DZA",  # Algeria
+    "ECU",  # Ecuador
+    "EGY",  # Egypt
+    "ERI",  # Eritrea
+    "ESH",  # Western Sahara
+    "ESP",  # Spain
+    "EST",  # Estonia
+    "ETH",  # Ethiopia
+    "FIN",  # Finland
+    "FJI",  # Fiji
+    "FLK",  # Falkland Islands (Malvinas)
+    "FRA",  # France
+    "FRO",  # Faroe Islands
+    "FSM",  # Micronesia (Federated States of)
+    "GAB",  # Gabon
+    "GBR",  # United Kingdom of Great Britain and Northern Ireland
+    "GEO",  # Georgia
+    "GGY",  # Guernsey
+    "GHA",  # Ghana
+    "GIB",  # Gibraltar
+    "GIN",  # Guinea
+    "GLP",  # Guadeloupe
+    "GMB",  # Gambia
+    "GNB",  # Guinea-Bissau
+    "GNQ",  # Equatorial Guinea
+    "GRC",  # Greece
+    "GRD",  # Grenada
+    "GRL",  # Greenland
+    "GTM",  # Guatemala
+    "GUF",  # French Guiana
+    "GUM",  # Guam
+    "GUY",  # Guyana
+    "HKG",  # Hong Kong
+    "HMD",  # Heard Island and McDonald Islands
+    "HND",  # Honduras
+    "HRV",  # Croatia
+    "HTI",  # Haiti
+    "HUN",  # Hungary
+    "IDN",  # Indonesia
+    "IMN",  # Isle of Man
+    "IND",  # India
+    "IOT",  # British Indian Ocean Territory
+    "IRL",  # Ireland
+    "IRN",  # Iran (Islamic Republic of)
+    "IRQ",  # Iraq
+    "ISL",  # Iceland
+    "ISR",  # Israel
+    "ITA",  # Italy
+    "JAM",  # Jamaica
+    "JEY",  # Jersey
+    "JOR",  # Jordan
+    "JPN",  # Japan
+    "KAZ",  # Kazakhstan
+    "KEN",  # Kenya
+    "KGZ",  # Kyrgyzstan
+    "KHM",  # Cambodia
+    "KIR",  # Kiribati
+    "KNA",  # Saint Kitts and Nevis
+    "KOR",  # Korea, Republic of
+    "KWT",  # Kuwait
+    "LAO",  # Lao People's Democratic Republic
+    "LBN",  # Lebanon
+    "LBR",  # Liberia
+    "LBY",  # Libya
+    "LCA",  # Saint Lucia
+    "LIE",  # Liechtenstein
+    "LKA",  # Sri Lanka
+    "LSO",  # Lesotho
+    "LTU",  # Lithuania
+    "LUX",  # Luxembourg
+    "LVA",  # Latvia
+    "MAC",  # Macao
+    "MAF",  # Saint Martin (French part)
+    "MAR",  # Morocco
+    "MCO",  # Monaco
+    "MDA",  # Moldova, Republic of
+    "MDG",  # Madagascar
+    "MDV",  # Maldives
+    "MEX",  # Mexico
+    "MHL",  # Marshall Islands
+    "MKD",  # North Macedonia
+    "MLI",  # Mali
+    "MLT",  # Malta
+    "MMR",  # Myanmar
+    "MNE",  # Montenegro
+    "MNG",  # Mongolia
+    "MNP",  # Northern Mariana Islands
+    "MOZ",  # Mozambique
+    "MRT",  # Mauritania
+    "MSR",  # Montserrat
+    "MTQ",  # Martinique
+    "MUS",  # Mauritius
+    "MWI",  # Malawi
+    "MYS",  # Malaysia
+    "MYT",  # Mayotte
+    "NAM",  # Namibia
+    "NCL",  # New Caledonia
+    "NER",  # Niger
+    "NFK",  # Norfolk Island
+    "NGA",  # Nigeria
+    "NIC",  # Nicaragua
+    "NIU",  # Niue
+    "NLD",  # Netherlands
+    "NOR",  # Norway
+    "NPL",  # Nepal
+    "NRU",  # Nauru
+    "NZL",  # New Zealand
+    "OMN",  # Oman
+    "PAK",  # Pakistan
+    "PAN",  # Panama
+    "PCN",  # Pitcairn
+    "PER",  # Peru
+    "PHL",  # Philippines
+    "PLW",  # Palau
+    "PNG",  # Papua New Guinea
+    "POL",  # Poland
+    "PRI",  # Puerto Rico
+    "PRK",  # Korea (Democratic People's Republic of)
+    "PRT",  # Portugal
+    "PRY",  # Paraguay
+    "PSE",  # Palestine, State of
+    "PYF",  # French Polynesia
+    "QAT",  # Qatar
+    "REU",  # Reunion
+    "ROU",  # Romania
+    "RUS",  # Russian Federation
+    "RWA",  # Rwanda
+    "SAU",  # Saudi Arabia
+    "SDN",  # Sudan
+    "SEN",  # Senegal
+    "SGP",  # Singapore
+    "SGS",  # South Georgia and the South Sandwich Islands
+    "SHN",  # Saint Helena, Ascension and Tristan da Cunha
+    "SJM",  # Svalbard and Jan Mayen
+    "SLB",  # Solomon Islands
+    "SLE",  # Sierra Leone
+    "SLV",  # El Salvador
+    "SMR",  # San Marino
+    "SOM",  # Somalia
+    "SPM",  # Saint Pierre and Miquelon
+    "SRB",  # Serbia
+    "SSD",  # South Sudan
+    "STP",  # Sao Tome and Principe
+    "SUR",  # Suriname
+    "SVK",  # Slovakia
+    "SVN",  # Slovenia
+    "SWE",  # Sweden
+    "SWZ",  # Eswatini
+    "SXM",  # Sint Maarten (Dutch part)
+    "SYC",  # Seychelles
+    "SYR",  # Syrian Arab Republic
+    "TCA",  # Turks and Caicos Islands
+    "TCD",  # Chad
+    "TGO",  # Togo
+    "THA",  # Thailand
+    "TJK",  # Tajikistan
+    "TKL",  # Tokelau
+    "TKM",  # Turkmenistan
+    "TLS",  # Timor-Leste
+    "TON",  # Tonga
+    "TTO",  # Trinidad and Tobago
+    "TUN",  # Tunisia
+    "TUR",  # Turkiye
+    "TUV",  # Tuvalu
+    "TWN",  # Taiwan, Province of China
+    "TZA",  # Tanzania, United Republic of
+    "UGA",  # Uganda
+    "UKR",  # Ukraine
+    "UMI",  # United States Minor Outlying Islands
+    "URY",  # Uruguay
+    "USA",  # United States of America
+    "UZB",  # Uzbekistan
+    "VAT",  # Holy See
+    "VCT",  # Saint Vincent and the Grenadines
+    "VEN",  # Venezuela (Bolivarian Republic of)
+    "VGB",  # Virgin Islands (British)
+    "VIR",  # Virgin Islands (U.S.)
+    "VNM",  # Viet Nam
+    "VUT",  # Vanuatu
+    "WLF",  # Wallis and Futuna
+    "WSM",  # Samoa
+    "YEM",  # Yemen
+    "ZAF",  # South Africa
+    "ZMB",  # Zambia
+    "ZWE",  # Zimbabwe
+]

--- a/src/aiai_eval/evaluator.py
+++ b/src/aiai_eval/evaluator.py
@@ -44,9 +44,6 @@ class Evaluator:
             available. Only relevant if `track_carbon_emissions` is set to True. A list
             of all such codes are available here:
             https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes
-        measure_power_secs (int):
-            How often power is measured, in seconds. Only relevant if
-            `track_carbon_emissions` is set to True.
 
     Attributes:
         evaluation_config (EvaluationConfig):
@@ -67,7 +64,6 @@ class Evaluator:
         verbose: bool = False,
         track_carbon_emissions: bool = False,
         country_iso_code: str = "",
-        measure_power_secs: int = 5,
     ):
         # Build evaluation configuration
         self.evaluation_config = EvaluationConfig(
@@ -79,7 +75,6 @@ class Evaluator:
             verbose=verbose,
             track_carbon_emissions=track_carbon_emissions,
             country_iso_code=country_iso_code,
-            measure_power_secs=measure_power_secs,
         )
 
         # Initialise variable storing model lists, so we only have to fetch it once

--- a/src/aiai_eval/evaluator.py
+++ b/src/aiai_eval/evaluator.py
@@ -1,4 +1,4 @@
-"""Main Evaluator class, used to evaluate models."""
+"""Main Evaluator class, used to evaluate finetuned models."""
 
 
 import json
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 
 class Evaluator:
-    """Evaluating provided Danish language models.
+    """Evaluating finetuned models.
 
     Args:
         progress_bar (bool, optional):
@@ -39,20 +39,18 @@ class Evaluator:
         track_carbon_emissions (bool):
             Whether to track carbon usage.
         country_iso_code (str):
-            The 3-letter alphabet ISO Code of the country where the compute infrastructure
-            is hosted. This is used when tracking carbon usage.
+            The 3-letter alphabet ISO Code of the country where the compute
+            infrastructure is hosted. Only relevant if no internet connection is
+            available. A list of all such codes are available here:
+            https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes
 
     Attributes:
-        progress_bar (bool):
-            Whether progress bars should be shown.
-        save_results (bool):
-            Whether to save the benchmark results.
-        verbose (bool):
-            Whether to output additional output.
-        use_auth_token (str or bool):
-            The authentication token for the Hugging Face Hub.
+        evaluation_config (EvaluationConfig):
+            The evaluation configuration.
         evaluation_results (dict):
-            The benchmark results.
+            The evaluation results.
+        task_factory (TaskFactory):
+            The factory object used to generate tasks to be evaluated.
     """
 
     def __init__(

--- a/src/aiai_eval/evaluator.py
+++ b/src/aiai_eval/evaluator.py
@@ -62,7 +62,7 @@ class Evaluator:
         use_auth_token: Union[bool, str] = False,
         verbose: bool = False,
         track_carbon_emissions: bool = False,
-        country_iso_code: str = "DNK",
+        country_iso_code: str = "",
     ):
         # Build evaluation configuration
         self.evaluation_config = EvaluationConfig(

--- a/src/aiai_eval/evaluator.py
+++ b/src/aiai_eval/evaluator.py
@@ -41,8 +41,12 @@ class Evaluator:
         country_iso_code (str):
             The 3-letter alphabet ISO Code of the country where the compute
             infrastructure is hosted. Only relevant if no internet connection is
-            available. A list of all such codes are available here:
+            available. Only relevant if `track_carbon_emissions` is set to True. A list
+            of all such codes are available here:
             https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes
+        measure_power_secs (int):
+            How often power is measured, in seconds. Only relevant if
+            `track_carbon_emissions` is set to True.
 
     Attributes:
         evaluation_config (EvaluationConfig):
@@ -63,6 +67,7 @@ class Evaluator:
         verbose: bool = False,
         track_carbon_emissions: bool = False,
         country_iso_code: str = "",
+        measure_power_secs: int = 5,
     ):
         # Build evaluation configuration
         self.evaluation_config = EvaluationConfig(
@@ -74,6 +79,7 @@ class Evaluator:
             verbose=verbose,
             track_carbon_emissions=track_carbon_emissions,
             country_iso_code=country_iso_code,
+            measure_power_secs=measure_power_secs,
         )
 
         # Initialise variable storing model lists, so we only have to fetch it once

--- a/src/aiai_eval/task.py
+++ b/src/aiai_eval/task.py
@@ -98,7 +98,6 @@ class Task(ABC):
             self.carbon_tracker = get_carbon_tracker(
                 task_name=self.task_config.name,
                 country_iso_code=self.evaluation_config.country_iso_code,
-                measure_power_secs=self.evaluation_config.measure_power_secs,
                 verbose=self.evaluation_config.verbose,
             )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,5 @@ def evaluation_config():
         verbose=True,
         track_carbon_emissions=True,
         country_iso_code="DNK",
-        measure_power_secs=5,
         testing=True,
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ def evaluation_config():
     yield EvaluationConfig(
         raise_error_on_invalid_model=True,
         cache_dir="cache_dir",
-        use_auth_token=True,
+        use_auth_token=False,
         progress_bar=True,
         save_results=True,
         verbose=True,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,21 @@
+"""Global fixtures for unit tests."""
+
+import pytest
+
+from src.aiai_eval.config import EvaluationConfig
+
+
+@pytest.fixture(scope="session")
+def evaluation_config():
+    yield EvaluationConfig(
+        raise_error_on_invalid_model=True,
+        cache_dir="cache_dir",
+        use_auth_token=True,
+        progress_bar=True,
+        save_results=True,
+        verbose=True,
+        track_carbon_emissions=True,
+        country_iso_code="DNK",
+        measure_power_secs=5,
+        testing=True,
+    )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -20,7 +20,6 @@ def test_cli_param_names(params):
         "use_auth_token",
         "track_carbon_emissions",
         "country_iso_code",
-        "measure_power_secs",
         "no_progress_bar",
         "no_save_results",
         "raise_error_on_invalid_model",
@@ -37,7 +36,6 @@ def test_cli_param_types(params):
     assert params["use_auth_token"] == BOOL
     assert params["track_carbon_emissions"] == BOOL
     assert params["country_iso_code"] == STRING
-    assert params["measure_power_secs"] == INT
     assert params["no_progress_bar"] == BOOL
     assert params["no_save_results"] == BOOL
     assert params["raise_error_on_invalid_model"] == BOOL

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,7 @@
 """Unit tests for the `cli` module."""
 
 import pytest
-from click.types import BOOL, STRING, Choice
+from click.types import BOOL, INT, STRING, Choice
 
 from src.aiai_eval.cli import evaluate
 
@@ -20,6 +20,7 @@ def test_cli_param_names(params):
         "use_auth_token",
         "track_carbon_emissions",
         "country_iso_code",
+        "measure_power_secs",
         "no_progress_bar",
         "no_save_results",
         "raise_error_on_invalid_model",
@@ -36,6 +37,7 @@ def test_cli_param_types(params):
     assert params["use_auth_token"] == BOOL
     assert params["track_carbon_emissions"] == BOOL
     assert params["country_iso_code"] == STRING
+    assert params["measure_power_secs"] == INT
     assert params["no_progress_bar"] == BOOL
     assert params["no_save_results"] == BOOL
     assert params["raise_error_on_invalid_model"] == BOOL

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,7 @@
 """Unit tests for the `cli` module."""
 
 import pytest
-from click.types import BOOL, INT, STRING, Choice
+from click.types import BOOL, STRING, Choice
 
 from src.aiai_eval.cli import evaluate
 
@@ -35,7 +35,7 @@ def test_cli_param_types(params):
     assert params["auth_token"] == STRING
     assert params["use_auth_token"] == BOOL
     assert params["track_carbon_emissions"] == BOOL
-    assert params["country_iso_code"] == STRING
+    assert isinstance(params["country_iso_code"], Choice)
     assert params["no_progress_bar"] == BOOL
     assert params["no_save_results"] == BOOL
     assert params["raise_error_on_invalid_model"] == BOOL

--- a/tests/test_co2.py
+++ b/tests/test_co2.py
@@ -1,0 +1,1 @@
+"""Unit tests for the `co2` module."""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -111,7 +111,7 @@ class TestEvaluationConfig:
     def test_attributes_correspond_to_arguments(self, evaluation_config):
         assert evaluation_config.raise_error_on_invalid_model is True
         assert evaluation_config.cache_dir == "cache_dir"
-        assert evaluation_config.use_auth_token is True
+        assert evaluation_config.use_auth_token is False
         assert evaluation_config.progress_bar is True
         assert evaluation_config.save_results is True
         assert evaluation_config.verbose is True

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -105,18 +105,6 @@ class TestTaskConfig:
 
 
 class TestEvaluationConfig:
-    @pytest.fixture(scope="class")
-    def evaluation_config(self):
-        yield EvaluationConfig(
-            raise_error_on_invalid_model=True,
-            cache_dir="cache_dir",
-            use_auth_token=True,
-            progress_bar=True,
-            save_results=True,
-            verbose=True,
-            testing=True,
-        )
-
     def test_evaluation_config_is_object(self, evaluation_config):
         assert isinstance(evaluation_config, EvaluationConfig)
 

--- a/tests/test_country_codes.py
+++ b/tests/test_country_codes.py
@@ -1,0 +1,1 @@
+"""Unit tests for the `country_codes` module."""

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -1,0 +1,1 @@
+"""Unit tests for the `evaluator` module."""

--- a/tests/test_hf_hub.py
+++ b/tests/test_hf_hub.py
@@ -2,24 +2,12 @@
 
 import pytest
 
-from src.aiai_eval.config import EvaluationConfig, ModelConfig
+from src.aiai_eval.config import ModelConfig
 from src.aiai_eval.exceptions import ModelDoesNotExistOnHuggingFaceHub
 from src.aiai_eval.hf_hub import get_model_config, model_exists_on_hf_hub
 
 
 class TestGetModelConfig:
-    @pytest.fixture(scope="class")
-    def evaluation_config(self):
-        yield EvaluationConfig(
-            raise_error_on_invalid_model=True,
-            cache_dir="cache_dir",
-            use_auth_token=False,
-            progress_bar=True,
-            save_results=True,
-            verbose=True,
-            testing=True,
-        )
-
     @pytest.fixture(scope="class")
     def model_config(self, evaluation_config):
         yield get_model_config(

--- a/tests/test_task_factory.py
+++ b/tests/test_task_factory.py
@@ -2,24 +2,11 @@
 
 import pytest
 
-from src.aiai_eval.config import EvaluationConfig, Label
+from src.aiai_eval.config import Label
 from src.aiai_eval.named_entity_recognition import NamedEntityRecognition
 from src.aiai_eval.task_configs import NER, SENT
 from src.aiai_eval.task_factory import TaskFactory
 from src.aiai_eval.text_classification import TextClassification
-
-
-@pytest.fixture(scope="module")
-def evaluation_config():
-    yield EvaluationConfig(
-        raise_error_on_invalid_model=True,
-        cache_dir="cache_dir",
-        use_auth_token=True,
-        progress_bar=True,
-        save_results=True,
-        verbose=True,
-        testing=True,
-    )
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
This PR does the following:

- Moves carbon tracking related functions into separate `co2` module, to keeps things as modular as possible.
- Fixes some docstrings
- Moves global pytest fixtures to `conftest.py`
- Adds `country_codes.py` module with list of all country codes, used in the CLI