### PR TITLE
17 keyerror when evaluating sentiment analysis

### DIFF
--- a/src/aiai_eval/scoring.py
+++ b/src/aiai_eval/scoring.py
@@ -48,8 +48,8 @@ def log_scores(
         msg = f"{metric_cfg.pretty_name}:\n  - Test: {test_score:.4f} ± {test_se:.4f}"
 
         # Store the aggregated test scores
-        total_dict[f"test_{metric_cfg.name}"] = test_score
-        total_dict[f"test_{metric_cfg.name}_se"] = test_se
+        total_dict[metric_cfg.name] = test_score
+        total_dict[f"{metric_cfg.name}_se"] = test_se
 
         # Log the scores
         logger.info(msg)

--- a/src/aiai_eval/scoring.py
+++ b/src/aiai_eval/scoring.py
@@ -80,7 +80,7 @@ def aggregate_scores(
     """
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
-        test_scores = [dct[f"test_{metric_config.name}"] for dct in scores]
+        test_scores = [dct[metric_config.name] for dct in scores]
         test_score = np.mean(test_scores)
         if len(test_scores) > 1:
             sample_std = np.std(test_scores, ddof=1)

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -20,9 +20,9 @@ def metric_config():
 @pytest.fixture(scope="module")
 def scores(metric_config):
     yield [
-        {f"test_{metric_config.name}": 0.50},
-        {f"test_{metric_config.name}": 0.55},
-        {f"test_{metric_config.name}": 0.60},
+        {metric_config.name: 0.50},
+        {metric_config.name: 0.55},
+        {metric_config.name: 0.60},
     ]
 
 
@@ -32,7 +32,7 @@ class TestAggregateScores:
         agg_scores = aggregate_scores(scores=scores, metric_config=metric_config)
 
         # Manually compute the mean and standard error of the scores
-        test_scores = [dct[f"test_{metric_config.name}"] for dct in scores]
+        test_scores = [dct[metric_config.name] for dct in scores]
         mean = np.mean(test_scores)
         se = 1.96 * np.std(test_scores, ddof=1) / np.sqrt(len(test_scores))
 
@@ -69,8 +69,8 @@ class TestLogScores:
 
     def test_total_scores_keys(self, logged_scores, metric_config):
         assert sorted(logged_scores["total"].keys()) == [
-            f"test_{metric_config.name}",
-            f"test_{metric_config.name}_se",
+            metric_config.name,
+            f"{metric_config.name}_se",
         ]
 
     def test_total_scores_values_are_floats(self, logged_scores):


### PR DESCRIPTION
The prefixes were removed in #4 , but reintroduced in #7.

Either we introduce prefixes in `_evaluate_pytorch_jax_single_iteration` when appending scores to `return_scores` in line 336,  or we remove them as presented here. I prefer the latter as the prefix `test_` is superfluous, as we are always using the `test` split.

This fixes #17