### PR TITLE
Feat/add dataloader progress bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ ______________________________________________________________________
 [![Documentation](https://img.shields.io/badge/docs-passing-green)](https://alexandrainst.github.io/AIAI-eval/aiai_eval.html)
 [![License](https://img.shields.io/github/license/alexandrainst/AIAI-eval)](https://github.com/alexandrainst/AIAI-eval/blob/main/LICENSE)
 [![LastCommit](https://img.shields.io/github/last-commit/alexandrainst/AIAI-eval)](https://github.com/alexandrainst/AIAI-eval/commits/main)
-[![Code Coverage](https://img.shields.io/badge/Coverage-52%25-orange.svg)](https://github.com/alexandrainst/AIAI-eval/tree/dev/tests)
+[![Code Coverage](https://img.shields.io/badge/Coverage-54%25-orange.svg)](https://github.com/alexandrainst/AIAI-eval/tree/dev/tests)
 
 
 Developers:

--- a/poetry.lock
+++ b/poetry.lock
@@ -1026,6 +1026,14 @@ python-versions = ">=3.6"
 catalogue = ">=2.0.3,<2.1.0"
 
 [[package]]
+name = "termcolor"
+version = "1.1.0"
+description = "ANSII Color formatting for output in terminal."
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "thinc"
 version = "8.1.0"
 description = "A refreshing functional take on deep learning, compatible with your favorite libraries"
@@ -1275,7 +1283,7 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8,<3.11"
-content-hash = "98ac30bfced72f686b98087300d5a45f73ca4084f8166348dd9126a37da2fcef"
+content-hash = "a110426dd68fcdc74ccb39b136ed535aa9712f4798b25aa4649f4221a2f212c8"
 
 [metadata.files]
 aiohttp = [
@@ -2267,6 +2275,9 @@ srsly = [
     {file = "srsly-2.4.4-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8235975d943587b4d17fc10e860b11d9248f58c0b74e95f911bd70b24542c630"},
     {file = "srsly-2.4.4-cp39-cp39-win_amd64.whl", hash = "sha256:708623d4e4503fee4cd9c727d471ab6918b664e177fbe413b0ddd2debb45437a"},
     {file = "srsly-2.4.4.tar.gz", hash = "sha256:e8a06581627b6712f19c60241b7c14c2bb29ce86ef04f791379a79f1b249a128"},
+]
+termcolor = [
+    {file = "termcolor-1.1.0.tar.gz", hash = "sha256:1d6d69ce66211143803fbc56652b41d73b4a400a2891d7bf7a1cdf4c02de613b"},
 ]
 thinc = [
     {file = "thinc-8.1.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:bb45c8aabb3d4e646a25939096cc751cb4e0e4ff9d3bfdcce9fa64ff0622d348"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ huggingface-hub = ">=0.8.1,<1.0.0"
 datasets = "^2.4.0"
 codecarbon = "^2.1.3"
 fsspec = "^2022.7.1"
+termcolor = "^1.1.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.5"

--- a/src/aiai_eval/__init__.py
+++ b/src/aiai_eval/__init__.py
@@ -2,7 +2,34 @@
 .. include:: ../../README.md
 """
 
+import logging
+import os
+
+import colorama
 import pkg_resources
+from termcolor import colored
+
+from .evaluator import Evaluator  # noqa
+from .utils import block_terminal_output
 
 # Fetches the version of the package as defined in pyproject.toml
 __version__ = pkg_resources.get_distribution("aiai_eval").version
+
+
+# Block unwanted terminal outputs
+block_terminal_output()
+
+
+# Ensure that termcolor also works on Windows
+colorama.init()
+
+
+# Set up logging
+fmt = colored("%(asctime)s [%(levelname)s] <%(name)s>\n↳ ", "cyan") + colored(
+    "%(message)s", "yellow"
+)
+logging.basicConfig(level=logging.INFO, format=fmt)
+
+
+# Disable parallelisation when tokenizing, as that can lead to errors
+os.environ["TOKENIZERS_PARALLELISM"] = "false"

--- a/src/aiai_eval/evaluator.py
+++ b/src/aiai_eval/evaluator.py
@@ -114,6 +114,28 @@ class Evaluator:
         model_ids = self._prepare_model_ids(model_id)
         task_configs = self._prepare_task_configs(task_name=task)
 
+        # If there are multiple models and/or tasks specified, then we log an initial
+        # message containing all the upcoming evaluations. The individual (model, task)
+        # pairs will also be logged individually later
+        if len(model_ids) > 1 or len(task_configs) > 1:
+
+            # Prepare model string for logging
+            if len(model_ids) == 1:
+                model_str = f"{model_ids[0]} model"
+            else:
+                model_str = ", ".join(model_id for model_id in model_ids[:-1])
+                model_str += f" and {model_ids[-1]} models"
+
+            # Prepare task string for logging
+            if len(task_configs) == 1:
+                task_str = f"{task_configs[0].pretty_name} task"
+            else:
+                task_str = ", ".join(cfg.pretty_name for cfg in task_configs[:-1])
+                task_str += f" and {task_configs[-1].pretty_name} tasks"
+
+            # Log status
+            logger.info(f"Evaluating the {model_str} on the {task_str}.")
+
         # Evaluate all the models in `model_ids` on all the datasets in `dataset_tasks`
         for task_config in task_configs:
             for m_id in model_ids:
@@ -190,7 +212,9 @@ class Evaluator:
             task_config (TaskConfig):
                 The dataset task configuration to use.
         """
-        logger.info(f"Evaluating {model_id} on {task_config.pretty_name}")
+        logger.info(
+            f"Evaluating the {model_id} model on the {task_config.pretty_name} task."
+        )
 
         if not model_exists_on_hf_hub(model_id=model_id):
             raise ModelDoesNotExistOnHuggingFaceHub(model_id)
@@ -202,8 +226,8 @@ class Evaluator:
             logger.debug(f"Results:\n{results}")
         except InvalidEvaluation as e:
             logger.info(
-                f"{model_id} could not be evaluated on "
-                f"{task_config.pretty_name}. Skipping."
+                f"{model_id} could not be evaluated on {task_config.pretty_name}. "
+                "Skipping."
             )
             logger.debug(f'The error message was "{e}".')
 

--- a/src/aiai_eval/task.py
+++ b/src/aiai_eval/task.py
@@ -216,7 +216,7 @@ class Task(ABC):
         # Load the data collator
         data_collator = self._load_data_collator(tokenizer)
 
-        scores = []
+        scores = list()
         for idx in itr:
             while True:
                 test_itr_scores = self._evaluate_pytorch_jax_single_iteration(
@@ -280,8 +280,8 @@ class Task(ABC):
                 The keys in the dict correspond to the metrics and values
                 the corresponding values.
         """
-        scores = []
-        return_scores = {}
+        scores = list()
+        return_scores = dict()
         try:
             # Set random seeds to enforce reproducibility of the randomly
             # initialised weights
@@ -307,12 +307,20 @@ class Task(ABC):
                 test, batch_size=32, shuffle=True, collate_fn=data_collator  # type: ignore
             )
 
+            # Create progress bar
+            if self.evaluation_config.progress_bar:
+                itr = tqdm(
+                    dataloader, desc=f"Evaluating iteration {idx+1}", leave=False
+                )
+            else:
+                itr = dataloader
+
             # Start carbon emissions tracking
             if self.evaluation_config.track_carbon_emissions:
                 self.carbon_tracker.start()
 
             # Get model predictions
-            for batch in dataloader:
+            for batch in itr:
                 if isinstance(model, PreTrainedModel):
                     model_predictions = model(**batch).logits
                 elif isinstance(model, nn.Module):


### PR DESCRIPTION
This PR does the following:
- Sets up a dataloader progress bar for each iteration, which disappears when the iteration is finished. This is only enabled if `progress_bar` is True
- Added some more descriptive logging when starting evaluation, which takes into account if multiple models and/or tasks have been chosen.

Fixes #28, relies on PR #30.

