### PR TITLE
Devices and metric computation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ ______________________________________________________________________
 [![Documentation](https://img.shields.io/badge/docs-passing-green)](https://alexandrainst.github.io/AIAI-eval/aiai_eval.html)
 [![License](https://img.shields.io/github/license/alexandrainst/AIAI-eval)](https://github.com/alexandrainst/AIAI-eval/blob/main/LICENSE)
 [![LastCommit](https://img.shields.io/github/last-commit/alexandrainst/AIAI-eval)](https://github.com/alexandrainst/AIAI-eval/commits/main)
-[![Code Coverage](https://img.shields.io/badge/Coverage-54%25-orange.svg)](https://github.com/alexandrainst/AIAI-eval/tree/dev/tests)
+[![Code Coverage](https://img.shields.io/badge/Coverage-52%25-orange.svg)](https://github.com/alexandrainst/AIAI-eval/tree/dev/tests)
 
 
 Developers:

--- a/src/aiai_eval/cli.py
+++ b/src/aiai_eval/cli.py
@@ -4,6 +4,7 @@ from typing import Tuple, Union
 
 import click
 
+from .config import Device
 from .country_codes import ALL_COUNTRY_CODES
 from .evaluator import Evaluator
 from .task_configs import get_all_task_configs
@@ -88,16 +89,12 @@ from .task_configs import get_all_task_configs
     help="The directory where models are datasets are cached.",
 )
 @click.option(
-    "--prefer-mps",
-    is_flag=True,
+    "--prefer-device",
+    type=click.Choice(["cuda", "mps", "cpu"]),
+    default="cuda",
     show_default=True,
-    help="Whether to prefer MPS GPUs when available.",
-)
-@click.option(
-    "--prefer-cpu",
-    is_flag=True,
-    show_default=True,
-    help="Whether to prefer CPU.",
+    help="""The device to prefer when evaluating the model. If the device is not
+    available then another device will be used.""",
 )
 @click.option(
     "--verbose",
@@ -117,8 +114,7 @@ def evaluate(
     no_save_results: bool,
     raise_error_on_invalid_model: bool,
     cache_dir: str,
-    prefer_mps: bool,
-    prefer_cpu: bool,
+    prefer_device: Device,
     verbose: bool,
 ):
     """Benchmark finetuned models."""
@@ -143,8 +139,7 @@ def evaluate(
         use_auth_token=auth,
         track_carbon_emissions=track_carbon_emissions,
         country_iso_code=country_iso_code,
-        prefer_mps=prefer_mps,
-        prefer_cpu=prefer_cpu,
+        prefer_device=prefer_device,
         verbose=verbose,
     )
 

--- a/src/aiai_eval/cli.py
+++ b/src/aiai_eval/cli.py
@@ -88,6 +88,18 @@ from .task_configs import get_all_task_configs
     help="The directory where models are datasets are cached.",
 )
 @click.option(
+    "--prefer-mps",
+    is_flag=True,
+    show_default=True,
+    help="Whether to prefer MPS GPUs when available.",
+)
+@click.option(
+    "--prefer-cpu",
+    is_flag=True,
+    show_default=True,
+    help="Whether to prefer CPU.",
+)
+@click.option(
     "--verbose",
     "-v",
     is_flag=True,
@@ -105,6 +117,8 @@ def evaluate(
     no_save_results: bool,
     raise_error_on_invalid_model: bool,
     cache_dir: str,
+    prefer_mps: bool,
+    prefer_cpu: bool,
     verbose: bool,
 ):
     """Benchmark finetuned models."""
@@ -127,9 +141,11 @@ def evaluate(
         raise_error_on_invalid_model=raise_error_on_invalid_model,
         cache_dir=cache_dir,
         use_auth_token=auth,
-        verbose=verbose,
         track_carbon_emissions=track_carbon_emissions,
         country_iso_code=country_iso_code,
+        prefer_mps=prefer_mps,
+        prefer_cpu=prefer_cpu,
+        verbose=verbose,
     )
 
     # Perform the benchmark evaluation

--- a/src/aiai_eval/evaluator.py
+++ b/src/aiai_eval/evaluator.py
@@ -34,16 +34,20 @@ class Evaluator:
             specified then the token will be fetched from the Hugging Face CLI, where
             the user has logged in through `huggingface-cli login`. If a string is
             specified then it will be used as the token. Defaults to False.
-        verbose (bool, optional):
-            Whether to output additional output. Defaults to False.
-        track_carbon_emissions (bool):
-            Whether to track carbon usage.
-        country_iso_code (str):
+        track_carbon_emissions (bool, optional):
+            Whether to track carbon usage. Defaults to False.
+        country_iso_code (str, optional):
             The 3-letter alphabet ISO Code of the country where the compute
             infrastructure is hosted. Only relevant if no internet connection is
-            available. Only relevant if `track_carbon_emissions` is set to True. A list
-            of all such codes are available here:
+            available. Only relevant if `track_carbon_emissions` is set to True.
+            Defaults to the empty string. A list of all such codes are available here:
             https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes
+        prefer_mps (bool, optional):
+            Whether to prefer MPS GPUs when available. Defaults to False.
+        prefer_cpu (bool, optional):
+            Whether to prefer CPU. Defaults to False.
+        verbose (bool, optional):
+            Whether to output additional output. Defaults to False.
 
     Attributes:
         evaluation_config (EvaluationConfig):
@@ -61,9 +65,11 @@ class Evaluator:
         raise_error_on_invalid_model: bool = False,
         cache_dir: str = ".aiai_cache",
         use_auth_token: Union[bool, str] = False,
-        verbose: bool = False,
         track_carbon_emissions: bool = False,
         country_iso_code: str = "",
+        prefer_mps: bool = False,
+        prefer_cpu: bool = False,
+        verbose: bool = False,
     ):
         # Build evaluation configuration
         self.evaluation_config = EvaluationConfig(
@@ -75,6 +81,8 @@ class Evaluator:
             verbose=verbose,
             track_carbon_emissions=track_carbon_emissions,
             country_iso_code=country_iso_code,
+            prefer_mps=prefer_mps,
+            prefer_cpu=prefer_cpu,
         )
 
         # Initialise variable storing model lists, so we only have to fetch it once

--- a/src/aiai_eval/evaluator.py
+++ b/src/aiai_eval/evaluator.py
@@ -7,7 +7,7 @@ from collections import defaultdict
 from pathlib import Path
 from typing import Dict, Sequence, Union
 
-from .config import EvaluationConfig, TaskConfig
+from .config import Device, EvaluationConfig, TaskConfig
 from .exceptions import InvalidEvaluation, ModelDoesNotExistOnHuggingFaceHub
 from .hf_hub import model_exists_on_hf_hub
 from .task_configs import get_all_task_configs
@@ -42,10 +42,10 @@ class Evaluator:
             available. Only relevant if `track_carbon_emissions` is set to True.
             Defaults to the empty string. A list of all such codes are available here:
             https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes
-        prefer_mps (bool, optional):
-            Whether to prefer MPS GPUs when available. Defaults to False.
-        prefer_cpu (bool, optional):
-            Whether to prefer CPU. Defaults to False.
+        prefer_device (Device, optional):
+            The device to prefer when evaluating the model. If the device is not
+            available then another device will be used. Can be "cuda", "mps" and "cpu".
+            Defaults to "cuda".
         verbose (bool, optional):
             Whether to output additional output. Defaults to False.
 
@@ -67,8 +67,7 @@ class Evaluator:
         use_auth_token: Union[bool, str] = False,
         track_carbon_emissions: bool = False,
         country_iso_code: str = "",
-        prefer_mps: bool = False,
-        prefer_cpu: bool = False,
+        prefer_device: Device = Device.CUDA,
         verbose: bool = False,
     ):
         # Build evaluation configuration
@@ -81,8 +80,7 @@ class Evaluator:
             verbose=verbose,
             track_carbon_emissions=track_carbon_emissions,
             country_iso_code=country_iso_code,
-            prefer_mps=prefer_mps,
-            prefer_cpu=prefer_cpu,
+            prefer_device=prefer_device,
         )
 
         # Initialise variable storing model lists, so we only have to fetch it once

--- a/src/aiai_eval/task.py
+++ b/src/aiai_eval/task.py
@@ -5,7 +5,6 @@ import random
 import subprocess
 import warnings
 from abc import ABC, abstractmethod
-from functools import partial
 from subprocess import CalledProcessError
 from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 

--- a/src/aiai_eval/task_configs.py
+++ b/src/aiai_eval/task_configs.py
@@ -2,7 +2,8 @@
 
 from typing import Dict
 
-from .config import Label, MetricConfig, TaskConfig
+from .config import MetricConfig, TaskConfig
+from .utils import Label
 
 
 def get_all_task_configs() -> Dict[str, TaskConfig]:

--- a/src/aiai_eval/utils.py
+++ b/src/aiai_eval/utils.py
@@ -6,6 +6,7 @@ import os
 import random
 import re
 import warnings
+from typing import List
 
 import numpy as np
 import pkg_resources
@@ -117,3 +118,29 @@ def internet_connection_available() -> bool:
         return True
     except RequestException:
         return False
+
+
+def get_available_devices() -> List[str]:
+    """Gets the available devices.
+
+    This will check whether a CUDA GPU and MPS GPU is available.
+
+    Returns:
+        List[str]:
+            The available devices, sorted as ["cuda", "mps", "cpu"].
+    """
+    available_devices = list()
+
+    # Add CUDA to the list if it is available
+    if torch.cuda.is_available():
+        available_devices.append("cuda")
+
+    # Add MPS to the list if it is available
+    if torch.backends.mps.is_available():
+        available_devices.append("mps")
+
+    # Always add CPU to the list
+    available_devices.append("cpu")
+
+    # Return the list of available devices
+    return available_devices

--- a/src/aiai_eval/utils.py
+++ b/src/aiai_eval/utils.py
@@ -1,11 +1,13 @@
 """Utility functions for the project."""
 
+import enum
 import gc
 import logging
 import os
 import random
 import re
 import warnings
+from dataclasses import dataclass
 from typing import List
 
 import numpy as np
@@ -120,27 +122,59 @@ def internet_connection_available() -> bool:
         return False
 
 
-def get_available_devices() -> List[str]:
+class Device(str, enum.Enum):
+    """The compute device to use for the evaluation.
+
+    Attributes:
+        CPU:
+            CPU device.
+        MPS:
+            MPS GPU, used in M-series MacBooks.
+        CUDA:
+            CUDA GPU, used with NVIDIA GPUs.
+    """
+
+    CPU = "cpu"
+    MPS = "mps"
+    CUDA = "cuda"
+
+
+def get_available_devices() -> List[Device]:
     """Gets the available devices.
 
     This will check whether a CUDA GPU and MPS GPU is available.
 
     Returns:
-        List[str]:
-            The available devices, sorted as ["cuda", "mps", "cpu"].
+        list of Device objects:
+            The available devices, sorted as CUDA, MPS, CPU.
     """
     available_devices = list()
 
     # Add CUDA to the list if it is available
     if torch.cuda.is_available():
-        available_devices.append("cuda")
+        available_devices.append(Device.CUDA)
 
     # Add MPS to the list if it is available
     if torch.backends.mps.is_available():
-        available_devices.append("mps")
+        available_devices.append(Device.MPS)
 
     # Always add CPU to the list
-    available_devices.append("cpu")
+    available_devices.append(Device.CPU)
 
     # Return the list of available devices
     return available_devices
+
+
+@dataclass
+class Label:
+    """A label in a dataset task.
+
+    Attributes:
+        name (str):
+            The name of the label.
+        synonyms (list of str):
+            The synonyms of the label.
+    """
+
+    name: str
+    synonyms: List[str]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,6 @@ def evaluation_config():
         verbose=True,
         track_carbon_emissions=True,
         country_iso_code="DNK",
-        prefer_mps=False,
-        prefer_cpu=False,
+        prefer_device="cpu",
         testing=True,
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,5 +16,7 @@ def evaluation_config():
         verbose=True,
         track_carbon_emissions=True,
         country_iso_code="DNK",
+        prefer_mps=False,
+        prefer_cpu=False,
         testing=True,
     )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -24,8 +24,7 @@ def test_cli_param_names(params):
         "no_save_results",
         "raise_error_on_invalid_model",
         "cache_dir",
-        "prefer_mps",
-        "prefer_cpu",
+        "prefer_device",
         "verbose",
         "help",
     }
@@ -42,7 +41,6 @@ def test_cli_param_types(params):
     assert params["no_save_results"] == BOOL
     assert params["raise_error_on_invalid_model"] == BOOL
     assert params["cache_dir"] == STRING
-    assert params["prefer_mps"] == BOOL
-    assert params["prefer_cpu"] == BOOL
+    assert isinstance(params["prefer_device"], Choice)
     assert params["verbose"] == BOOL
     assert params["help"] == BOOL

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -24,6 +24,8 @@ def test_cli_param_names(params):
         "no_save_results",
         "raise_error_on_invalid_model",
         "cache_dir",
+        "prefer_mps",
+        "prefer_cpu",
         "verbose",
         "help",
     }
@@ -40,5 +42,7 @@ def test_cli_param_types(params):
     assert params["no_save_results"] == BOOL
     assert params["raise_error_on_invalid_model"] == BOOL
     assert params["cache_dir"] == STRING
+    assert params["prefer_mps"] == BOOL
+    assert params["prefer_cpu"] == BOOL
     assert params["verbose"] == BOOL
     assert params["help"] == BOOL


### PR DESCRIPTION
This PR implements the following:
- There is now a `get_available_devices` in `utils.py`, which returns the list of available devices, sorted from most powerful to least powerful (i.e., "cuda", "mps", "cpu").
- The `EvaluationConfig` now has `prefer_mps`, `prefer_cpu` and `device` properties, where the `device` property is set using the `get_available_devices` and the preferred devices. This is also implemented in the CLI, with `--prefer-mps` and `--prefer-cpu`.
- Changed the `Task._compute_metrics` metric to take in `predictions` and `labels` as separate arguments.
- Implemented a `Task. _prepare_predictions_and_labels` method, which defaults to not changing predictions and labels, but which allows individual tasks to do so (NER needs to do so, for instance).

This closes #33, and depends on PRs #34 and #30.