### PR TITLE
Tests/add co2 tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ ______________________________________________________________________
 [![Documentation](https://img.shields.io/badge/docs-passing-green)](https://alexandrainst.github.io/AIAI-eval/aiai_eval.html)
 [![License](https://img.shields.io/github/license/alexandrainst/AIAI-eval)](https://github.com/alexandrainst/AIAI-eval/blob/main/LICENSE)
 [![LastCommit](https://img.shields.io/github/last-commit/alexandrainst/AIAI-eval)](https://github.com/alexandrainst/AIAI-eval/commits/main)
-[![Code Coverage](https://img.shields.io/badge/Coverage-52%25-orange.svg)](https://github.com/alexandrainst/AIAI-eval/tree/dev/tests)
+[![Code Coverage](https://img.shields.io/badge/Coverage-54%25-orange.svg)](https://github.com/alexandrainst/AIAI-eval/tree/dev/tests)
 
 
 Developers:

--- a/src/aiai_eval/co2.py
+++ b/src/aiai_eval/co2.py
@@ -9,7 +9,7 @@ from .utils import internet_connection_available
 
 
 def get_carbon_tracker(
-    task_name: str, country_iso_code: str, verbose: bool
+    task_name: str, country_iso_code: str, verbose: bool, prefer_offline: bool = False
 ) -> Union[EmissionsTracker, OfflineEmissionsTracker]:
     """Prepares a carbon emissions tracker.
 
@@ -22,6 +22,8 @@ def get_carbon_tracker(
             https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes
         verbose (bool):
             Whether to print verbose output.
+        prefer_offline (bool, optional):
+            Whether to prefer offline carbon emissions tracker. Defaults to False.
 
     Returns:
         EmissionsTracker or OfflineEmissionsTracker:
@@ -30,17 +32,11 @@ def get_carbon_tracker(
     """
     log_level = "info" if verbose else "error"
 
-    if internet_connection_available():
-        carbon_tracker = EmissionsTracker(
-            project_name=task_name,
-            measure_power_secs=1,
-            log_level=log_level,
-            save_to_file=False,
-            save_to_api=False,
-            save_to_logger=False,
-        )
-    else:
-        # If country_iso_code is "", raise exception
+    # Use the offline emissions tracker if there is either no internet connection
+    # or the user wants to use the offline emissions tracker
+    if not internet_connection_available() or prefer_offline:
+
+        # If the country code is not specified then raise an error
         if country_iso_code == "":
             raise MissingCountryISOCode
 
@@ -53,4 +49,16 @@ def get_carbon_tracker(
             save_to_api=False,
             save_to_logger=False,
         )
+
+    # Otherwise use the online emissions tracker
+    else:
+        carbon_tracker = EmissionsTracker(
+            project_name=task_name,
+            measure_power_secs=1,
+            log_level=log_level,
+            save_to_file=False,
+            save_to_api=False,
+            save_to_logger=False,
+        )
+
     return carbon_tracker

--- a/tests/test_co2.py
+++ b/tests/test_co2.py
@@ -1,1 +1,34 @@
 """Unit tests for the `co2` module."""
+
+import pytest
+from codecarbon import EmissionsTracker, OfflineEmissionsTracker
+
+from aiai_eval.co2 import get_carbon_tracker
+
+
+class TestGetCarbonTracker:
+    @pytest.fixture(scope="class")
+    def params(self):
+        yield dict(task_name="test_task", country_iso_code="DNK", verbose=False)
+
+    @pytest.fixture(scope="class")
+    def online_carbon_tracker(self, params):
+        yield get_carbon_tracker(**params, prefer_offline=False)
+
+    @pytest.fixture(scope="class")
+    def offline_carbon_tracker(self, params):
+        yield get_carbon_tracker(**params, prefer_offline=True)
+
+    def test_get_carbon_tracker_online(self, online_carbon_tracker):
+        assert isinstance(online_carbon_tracker, EmissionsTracker)
+
+    def test_get_carbon_tracker_offline(self, offline_carbon_tracker):
+        assert isinstance(offline_carbon_tracker, OfflineEmissionsTracker)
+
+    def test_project_name(self, online_carbon_tracker, offline_carbon_tracker, params):
+        assert online_carbon_tracker._conf["project_name"] == params["task_name"]
+        assert offline_carbon_tracker._conf["project_name"] == params["task_name"]
+
+    def test_measure_power_secs(self, online_carbon_tracker, offline_carbon_tracker):
+        assert online_carbon_tracker._conf["measure_power_secs"] == 1
+        assert offline_carbon_tracker._conf["measure_power_secs"] == 1


### PR DESCRIPTION
This PR does the following:
- Adds unit tests for the `co2` module
- Adds a `prefer_offline` argument to the `get_carbon_tracker` function, defaulting to `False`

Closes #20 