### PR TITLE
Tests/add tests for text classification

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ ______________________________________________________________________
 [![Documentation](https://img.shields.io/badge/docs-passing-green)](https://alexandrainst.github.io/AIAI-eval/aiai_eval.html)
 [![License](https://img.shields.io/github/license/alexandrainst/AIAI-eval)](https://github.com/alexandrainst/AIAI-eval/blob/main/LICENSE)
 [![LastCommit](https://img.shields.io/github/last-commit/alexandrainst/AIAI-eval)](https://github.com/alexandrainst/AIAI-eval/commits/main)
-[![Code Coverage](https://img.shields.io/badge/Coverage-52%25-orange.svg)](https://github.com/alexandrainst/AIAI-eval/tree/dev/tests)
+[![Code Coverage](https://img.shields.io/badge/Coverage-59%25-orange.svg)](https://github.com/alexandrainst/AIAI-eval/tree/main/tests)
 
 
 Developers:

--- a/src/aiai_eval/named_entity_recognition.py
+++ b/src/aiai_eval/named_entity_recognition.py
@@ -60,9 +60,7 @@ class NamedEntityRecognition(Task):
         """
         pass
 
-    def _preprocess_data_pytorch(
-        self, dataset: Dataset, framework: str, **kwargs
-    ) -> list:
+    def _preprocess_data_pytorch(self, dataset: Dataset, **kwargs) -> list:
         """Preprocess a dataset by tokenizing and aligning the labels.
 
         For use by a PyTorch model.
@@ -70,14 +68,13 @@ class NamedEntityRecognition(Task):
         Args:
             dataset (Hugging Face dataset):
                 The dataset to preprocess.
-            framework (str):
-                Specification of which framework the model is created in.
             kwargs:
                 Extra keyword arguments containing objects used in preprocessing the
                 dataset.
 
         Returns:
-            Hugging Face dataset:
-                The preprocessed dataset.
+            list of lists:
+                Every list element represents the tokenised data for the corresponding
+                example.
         """
         return list(dataset)

--- a/src/aiai_eval/task.py
+++ b/src/aiai_eval/task.py
@@ -794,12 +794,10 @@ class Task(ABC):
         return model
 
     @abstractmethod
-    def _preprocess_data_pytorch(
-        self, dataset: Dataset, framework: str, **kwargs
-    ) -> list:
+    def _preprocess_data_pytorch(self, dataset: Dataset, **kwargs) -> list:
         """Preprocess a dataset by tokenizing and aligning the labels.
 
-        For use by a pytorch model.
+        For use by a PyTorch model.
 
         Args:
             dataset (Hugging Face dataset):
@@ -809,7 +807,9 @@ class Task(ABC):
                 dataset.
 
         Returns:
-            Hugging Face dataset: The preprocessed dataset.
+            list of lists:
+                Every list element represents the tokenised data for the corresponding
+                example.
         """
         pass
 

--- a/src/aiai_eval/task.py
+++ b/src/aiai_eval/task.py
@@ -185,7 +185,6 @@ class Task(ABC):
                 framework="pytorch",
                 config=model.config,
                 tokenizer=tokenizer,
-                task_config=self.task_config,
             )
             # Do framework specific preprocessing
             if isinstance(model, PreTrainedModel):

--- a/src/aiai_eval/text_classification.py
+++ b/src/aiai_eval/text_classification.py
@@ -55,26 +55,26 @@ class TextClassification(Task):
         def tokenise(examples: dict) -> dict:
             try:
                 return tokenizer(
-                    examples[kwargs["task_config"].feature_column_name],
+                    examples[self.task_config.feature_column_name],
                     truncation=True,
                     padding=True,
                 )
             except KeyError:
-                raise WrongFeatureColumnName(kwargs["task_config"].feature_column_name)
+                raise WrongFeatureColumnName(self.task_config.feature_column_name)
 
         # Tokenise
         tokenised = dataset.map(tokenise, batched=True, load_from_cache_file=False)
 
         # Translate labels to ids
         numericalise = partial(
-            self._create_numerical_labels, label2id=kwargs["task_config"].label2id
+            self._create_numerical_labels, label2id=self.task_config.label2id
         )
         preprocessed = tokenised.map(
             numericalise, batched=True, load_from_cache_file=False
         )
 
         # Remove unused column
-        return preprocessed.remove_columns(kwargs["task_config"].feature_column_name)
+        return preprocessed.remove_columns(self.task_config.feature_column_name)
 
     def _preprocess_data_pytorch(
         self, dataset: Dataset, framework: str, **kwargs

--- a/src/aiai_eval/text_classification.py
+++ b/src/aiai_eval/text_classification.py
@@ -76,9 +76,7 @@ class TextClassification(Task):
         # Remove unused column
         return preprocessed.remove_columns(self.task_config.feature_column_name)
 
-    def _preprocess_data_pytorch(
-        self, dataset: Dataset, framework: str, **kwargs
-    ) -> list:
+    def _preprocess_data_pytorch(self, dataset: Dataset, **kwargs) -> list:
         """Preprocess a dataset by tokenizing and aligning the labels.
 
         For use by a PyTorch model.
@@ -96,7 +94,7 @@ class TextClassification(Task):
                 example.
         """
         full_preprocessed = self._preprocess_data_transformer(
-            dataset=dataset, framework=framework, **kwargs
+            dataset=dataset, framework="pytorch", **kwargs
         )
         return full_preprocessed["input_ids"]
 

--- a/src/aiai_eval/text_classification.py
+++ b/src/aiai_eval/text_classification.py
@@ -91,8 +91,9 @@ class TextClassification(Task):
                 dataset.
 
         Returns:
-            Hugging Face dataset:
-                The preprocessed dataset.
+            list of lists:
+                Every list element represents the tokenised data for the corresponding
+                example.
         """
         full_preprocessed = self._preprocess_data_transformer(
             dataset=dataset, framework=framework, **kwargs
@@ -100,6 +101,21 @@ class TextClassification(Task):
         return full_preprocessed["input_ids"]
 
     def _create_numerical_labels(self, examples: dict, label2id: dict) -> dict:
+        """Create numerical labels from the labels.
+
+        Args:
+            examples (dict):
+                The examples to create numerical labels for.
+            label2id (dict):
+                The mapping from labels to ids.
+
+        Returns:
+            dict: The examples with numerical labels.
+
+        Raises:
+            MissingLabel:
+                If a label is missing in the `label2id` mapping.
+        """
         try:
             examples["label"] = [label2id[lbl.upper()] for lbl in examples["label"]]
         except KeyError:

--- a/src/aiai_eval/text_classification.py
+++ b/src/aiai_eval/text_classification.py
@@ -117,7 +117,10 @@ class TextClassification(Task):
         try:
             examples["label"] = [label2id[lbl.upper()] for lbl in examples["label"]]
         except KeyError:
-            raise MissingLabel(label=examples["label"].upper(), label2id=label2id)
+            missing_label = [
+                lbl.upper() for lbl in examples["label"] if lbl.upper() not in label2id
+            ][0]
+            raise MissingLabel(label=missing_label, label2id=label2id)
         return examples
 
     def _load_data_collator(self, tokenizer: PreTrainedTokenizerBase):

--- a/tests/test_text_classification.py
+++ b/tests/test_text_classification.py
@@ -1,1 +1,132 @@
 """Unit tests for the `text_classification` module."""
+
+from copy import deepcopy
+
+import pytest
+from datasets import Dataset, load_dataset
+from transformers import AutoTokenizer, DataCollatorWithPadding
+
+from src.aiai_eval.exceptions import (
+    InvalidEvaluation,
+    MissingLabel,
+    WrongFeatureColumnName,
+)
+from src.aiai_eval.task_configs import SENT
+from src.aiai_eval.text_classification import TextClassification
+
+
+@pytest.fixture(scope="module")
+def dataset():
+    yield load_dataset("DDSC/angry-tweets", split="train")
+
+
+@pytest.fixture(scope="module")
+def text_clf(evaluation_config):
+    yield TextClassification(task_config=SENT, evaluation_config=evaluation_config)
+
+
+@pytest.fixture(scope="module")
+def tokenizer():
+    yield AutoTokenizer.from_pretrained("pin/senda")
+
+
+class TestPreprocessDataTransformer:
+    @pytest.fixture(scope="class")
+    def preprocessed(self, dataset, text_clf, tokenizer):
+        yield text_clf._preprocess_data_transformer(
+            dataset=dataset,
+            framework="pytorch",
+            tokenizer=tokenizer,
+        )
+
+    def test_spacy_framework_throws_exception(self, dataset, text_clf, tokenizer):
+        with pytest.raises(InvalidEvaluation):
+            text_clf._preprocess_data_transformer(
+                dataset=dataset,
+                framework="spacy",
+                tokenizer=tokenizer,
+            )
+
+    def test_preprocessed_is_dataset(self, preprocessed):
+        assert isinstance(preprocessed, Dataset)
+
+    def test_preprocessed_columns(self, preprocessed):
+        assert list(preprocessed.features.keys()) == [
+            "label",
+            "input_ids",
+            "token_type_ids",
+            "attention_mask",
+        ]
+
+    def test_throw_exception_if_feature_column_name_is_wrong(
+        self, dataset, evaluation_config, tokenizer
+    ):
+        # Create copy of the sentiment analysis task config, with a wrong feature
+        # column name
+        sent_cfg_copy = deepcopy(SENT)
+        sent_cfg_copy.feature_column_name = "wrong_name"
+
+        # Create a text classification task with the wrong feature column name
+        text_clf_copy = TextClassification(
+            task_config=sent_cfg_copy, evaluation_config=evaluation_config
+        )
+
+        # Attempt to preprocess the dataset with the wrong feature column name
+        with pytest.raises(WrongFeatureColumnName):
+            text_clf_copy._preprocess_data_transformer(
+                dataset=dataset,
+                framework="pytorch",
+                tokenizer=tokenizer,
+            )
+
+
+class TestPreprocessDataPyTorch:
+    @pytest.fixture(scope="class")
+    def preprocessed(self, dataset, text_clf, tokenizer):
+        yield text_clf._preprocess_data_pytorch(
+            dataset=dataset,
+            tokenizer=tokenizer,
+        )
+
+    def test_preprocessed_is_list(self, preprocessed):
+        assert isinstance(preprocessed, list)
+
+
+class TestCreateNumericalLabels:
+    @pytest.fixture(scope="class")
+    def examples(self):
+        yield dict(label=["POSITIVE", "POSITIVE", "NEGATIVE", "NEUTRAL"])
+
+    @pytest.fixture(scope="class")
+    def label2id(self):
+        yield dict(NEGATIVE=0, NEUTRAL=1, POSITIVE=2)
+
+    def test_output_is_dict(self, text_clf, examples, label2id):
+        numerical_labels = text_clf._create_numerical_labels(
+            examples=examples, label2id=label2id
+        )
+        assert isinstance(numerical_labels, dict)
+
+    def throw_exception_if_label_is_missing(self, text_clf, label2id):
+        with pytest.raises(MissingLabel):
+            text_clf._create_numerical_labels(
+                examples=dict(label=["not-a-label"]),
+                label2id=label2id,
+            )
+
+
+class TestLoadDataCollator:
+    @pytest.fixture(scope="class")
+    def data_collator(self, text_clf, tokenizer):
+        yield text_clf._load_data_collator(tokenizer=tokenizer)
+
+    def test_data_collator_dtype(self, data_collator):
+        assert isinstance(data_collator, DataCollatorWithPadding)
+
+    def test_padding_is_longest(self, data_collator):
+        assert data_collator.padding == "longest"
+
+
+def test_get_spacy_predictions_and_labels_raises_exception(text_clf):
+    with pytest.raises(InvalidEvaluation):
+        text_clf._get_spacy_predictions_and_labels(model=None, dataset=None)


### PR DESCRIPTION
This PR does the following:
- Adds unit tests for the `text_classification` module
- Fixes in error in the raising of the `MissingLabel` exception
- In the preprocessing methods it now uses `self.task_config` rather than expecting it to be in the kwargs
- The `_preprocess_data_pytorch` method now does not accept a `framework` argument, as it is assumed to be 'pytorch'
- Fixes the coverage badge URL in the README (was referring to a non-existing `dev` branch instead of the `main` branch)

Closes #14 