### PR TITLE
Feat/v0.0.x

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,7 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-title: "[BUG]"
+title: "[BUG] "
 labels: bug
 assignees: ''
 
@@ -11,11 +11,7 @@ assignees: ''
 A clear and concise description of what the bug is.
 
 **To Reproduce**
-Steps to reproduce the behaviour:
-1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
-4. See error
+Steps to reproduce the behaviour.
 
 **Expected behaviour**
 A clear and concise description of what you expected to happen.
@@ -24,8 +20,9 @@ A clear and concise description of what you expected to happen.
 If applicable, add screenshots to help explain your problem.
 
 **Desktop (please complete the following information):**
- - OS: [e.g. iOS]
- - Package version [e.g. 22]
+ - OS [e.g., iOS]:
+ - Python version [e.g., 3.10.6]:
+ - Package version [e.g., 0.1.2]:
 
 **Additional context**
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,7 +1,7 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-title: "[FEATURE-REQUEST]"
+title: "[FEATURE-REQUEST] "
 labels: enhancement
 assignees: ''
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,9 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main

--- a/.gitignore
+++ b/.gitignore
@@ -91,6 +91,9 @@ target/
 
 # Documentation
 docs/aiai_eval/
+docs/aiai_eval.html
+docs/index.html
+docs/search.json
 
 # AIAI
 .aiai_cache/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
-## [Unreleased]
+## [v0.0.1] - 2022-08-29
 ### Added
 - First release, which includes evaluation of sentiment models from the Hugging Face
   Hub. This can be run with the CLI using the `evaluate` command, or via a script using

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this
+project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+
+## [Unreleased]
+### Added
+- First release, which includes evaluation of sentiment models from the Hugging Face
+  Hub. This can be run with the CLI using the `evaluate` command, or via a script using
+  the `Evaluator` class.

--- a/makefile
+++ b/makefile
@@ -56,7 +56,14 @@ docs:
 
 view-docs:
 	@echo "Viewing API documentation..."
-	@open docs/aiai_eval.html
+	@uname=$$(uname); \
+		case $${uname} in \
+			(*Linux*) openCmd='xdg-open'; ;; \
+			(*Darwin*) openCmd='open'; ;; \
+			(*CYGWIN*) openCmd='cygstart'; ;; \
+			(*) echo 'Error: Unsupported platform: $${uname}'; exit 2; ;; \
+		esac; \
+		"$${openCmd}" docs/aiai_eval.html
 
 bump-major:
 	@poetry run python -m src.scripts.versioning --major

--- a/makefile
+++ b/makefile
@@ -28,13 +28,14 @@ install:
 			 "`make install` again."; \
 	fi
 	@$(MAKE) setup-poetry
+	@$(MAKE) setup-environment-variables
 	@$(MAKE) setup-git
 
 setup-poetry:
-	@poetry env use python3
+	@poetry env use python3 && poetry install
+
+setup-environment-variables:
 	@poetry run python3 -m src.scripts.fix_dot_env_file
-	@poetry install
-	@poetry run pre-commit install
 
 setup-git:
 	@git init
@@ -49,6 +50,7 @@ setup-git:
 		git config --local commit.gpgsign true; \
 		git config --local user.signingkey ${GPG_KEY_ID}; \
 	fi
+	@poetry run pre-commit install
 
 docs:
 	@poetry run pdoc --docformat google src/aiai_eval -o docs
@@ -65,36 +67,31 @@ view-docs:
 		esac; \
 		"$${openCmd}" docs/aiai_eval.html
 
-bump-major:
+publish-major:
 	@poetry run python -m src.scripts.versioning --major
-	@echo "Bumped major version."
+	@$(MAKE) publish
+	@echo "Published major version!"
 
-bump-minor:
+publish-minor:
 	@poetry run python -m src.scripts.versioning --minor
-	@echo "Bumped minor version."
+	@$(MAKE) publish
+	@echo "Published minor version!"
 
-bump-patch:
+publish-patch:
 	@poetry run python -m src.scripts.versioning --patch
-	@echo "Bumped patch version."
+	@$(MAKE) publish
+	@echo "Published patch version!"
 
 publish:
-	@$(eval include .env)
-	@printf "Preparing to publish to PyPI. Have you ensured to change the package version with 'make bump-X' for 'X' being 'major', 'minor' or 'patch'? [y/n] : "; \
-		read -r answer; \
-		if [ "$${answer}" = "y" ]; then \
-			if [ "${PYPI_API_TOKEN}" = "" ]; then \
-				echo "No PyPI API token specified in the '.env' file, so cannot publish."; \
-			else \
-				echo "Publishing to PyPI..."; \
-				poetry publish --build --username "__token__" --password "${PYPI_API_TOKEN}"; \
-				echo "Published!"; \
-			fi \
-		else \
-			echo "Publishing aborted."; \
-		fi
+	@if [ ${PYPI_API_TOKEN} = "" ]; then \
+		echo "No PyPI API token specified in the '.env' file, so cannot publish."; \
+	else \
+		echo "Publishing to PyPI..."; \
+		poetry publish --build --username "__token__" --password ${PYPI_API_TOKEN}; \
+	fi
 
 test:
-	@python -m pytest && readme-cov
+	@poetry run pytest && readme-cov
 
 tree:
 	@tree -a \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aiai_eval"
-version = "0.0.0"
+version = "0.0.1"
 description = "Evaluation of finetuned models."
 authors = [
     "Dan Saattrup Nielsen <dan.nielsen@alexandra.dk>",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "AIAI-Eval"
-version = "0.0.1"
+version = "0.0.0"
 description = "Evaluation of finetuned models."
 authors = [
     "Dan Saattrup Nielsen <dan.nielsen@alexandra.dk>",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-name = "AIAI-Eval"
+name = "aiai_eval"
 version = "0.0.0"
 description = "Evaluation of finetuned models."
 authors = [


### PR DESCRIPTION
This branch will contain all patch version of version 0.0.

This PR includes the following changes:
- Small stylistic changes to issue templates
- Do not run CI action when pushing, as we are only using PRs anyway
- Some changes to makefile: instead of `bump-X` for X being 'patch', 'minor' or 'major', it now has `publish-X`. Also, the `view-docs` recipe now works when not on MacOS.
- Added `CHANGELOG.md`, containing all changes made in the version.