### PR TITLE
Feat/local models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ aiai_evaluation_results.json
 # Gradio logs
 flagged/
 gradio_cached_examples/
+
+# Data
+attack/

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ ______________________________________________________________________
 [![Documentation](https://img.shields.io/badge/docs-passing-green)](https://alexandrainst.github.io/AIAI-eval/aiai_eval.html)
 [![License](https://img.shields.io/github/license/alexandrainst/AIAI-eval)](https://github.com/alexandrainst/AIAI-eval/blob/main/LICENSE)
 [![LastCommit](https://img.shields.io/github/last-commit/alexandrainst/AIAI-eval)](https://github.com/alexandrainst/AIAI-eval/commits/main)
-[![Code Coverage](https://img.shields.io/badge/Coverage-87%25-yellowgreen.svg)](https://github.com/alexandrainst/AIAI-eval/tree/main/tests)
+[![Code Coverage](https://img.shields.io/badge/Coverage-81%25-yellowgreen.svg)](https://github.com/alexandrainst/AIAI-eval/tree/main/tests)
 
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ ______________________________________________________________________
 [![Documentation](https://img.shields.io/badge/docs-passing-green)](https://alexandrainst.github.io/AIAI-eval/aiai_eval.html)
 [![License](https://img.shields.io/github/license/alexandrainst/AIAI-eval)](https://github.com/alexandrainst/AIAI-eval/blob/main/LICENSE)
 [![LastCommit](https://img.shields.io/github/last-commit/alexandrainst/AIAI-eval)](https://github.com/alexandrainst/AIAI-eval/commits/main)
-[![Code Coverage](https://img.shields.io/badge/Coverage-82%25-yellowgreen.svg)](https://github.com/alexandrainst/AIAI-eval/tree/main/tests)
+[![Code Coverage](https://img.shields.io/badge/Coverage-81%25-yellowgreen.svg)](https://github.com/alexandrainst/AIAI-eval/tree/main/tests)
 
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ ______________________________________________________________________
 [![Documentation](https://img.shields.io/badge/docs-passing-green)](https://alexandrainst.github.io/AIAI-eval/aiai_eval.html)
 [![License](https://img.shields.io/github/license/alexandrainst/AIAI-eval)](https://github.com/alexandrainst/AIAI-eval/blob/main/LICENSE)
 [![LastCommit](https://img.shields.io/github/last-commit/alexandrainst/AIAI-eval)](https://github.com/alexandrainst/AIAI-eval/commits/main)
-[![Code Coverage](https://img.shields.io/badge/Coverage-81%25-yellowgreen.svg)](https://github.com/alexandrainst/AIAI-eval/tree/main/tests)
+[![Code Coverage](https://img.shields.io/badge/Coverage-82%25-yellowgreen.svg)](https://github.com/alexandrainst/AIAI-eval/tree/main/tests)
 
 
 ## Installation

--- a/src/aiai_eval/__init__.py
+++ b/src/aiai_eval/__init__.py
@@ -4,7 +4,6 @@
 
 import logging
 import os
-import sys
 
 import colorama
 import pkg_resources
@@ -43,7 +42,3 @@ os.environ["PYTORCH_ENABLE_MPS_FALLBACK"] = "1"
 # Tell Windows machines to use UTF-8 encoding
 os.environ["ConEmuDefaultCp"] = "65001"
 os.environ["PYTHONIOENCODING"] = "UTF-8"
-
-
-# Remove traceback in error handling
-sys.tracebacklimit = 0

--- a/src/aiai_eval/__init__.py
+++ b/src/aiai_eval/__init__.py
@@ -4,6 +4,7 @@
 
 import logging
 import os
+import sys
 
 import colorama
 import pkg_resources
@@ -42,3 +43,7 @@ os.environ["PYTORCH_ENABLE_MPS_FALLBACK"] = "1"
 # Tell Windows machines to use UTF-8 encoding
 os.environ["ConEmuDefaultCp"] = "65001"
 os.environ["PYTHONIOENCODING"] = "UTF-8"
+
+
+# Remove traceback in error handling
+sys.tracebacklimit = 0

--- a/src/aiai_eval/cli.py
+++ b/src/aiai_eval/cli.py
@@ -1,6 +1,6 @@
 """Command-line interface for evaluation of models."""
 
-from typing import Tuple, Union
+from typing import Optional, Tuple, Union
 
 import click
 
@@ -97,6 +97,22 @@ from .task_configs import get_all_task_configs
     available then another device will be used.""",
 )
 @click.option(
+    "--architecture-fname",
+    type=str,
+    default="None",
+    help="""The name of the architecture file, if local models are used. If None, the
+    architecture file will be automatically detected as the first Python script in the
+    model directory. Defaults to None.""",
+)
+@click.option(
+    "--weight-fname",
+    type=str,
+    default="None",
+    help="""The name of the file containing the model weights, if local models are
+    used. If None, the architecture file will be automatically detected as the first
+    Python script in the model directory. Defaults to None.""",
+)
+@click.option(
     "--verbose",
     "-v",
     is_flag=True,
@@ -115,6 +131,8 @@ def evaluate(
     raise_error_on_invalid_model: bool,
     cache_dir: str,
     prefer_device: str,
+    architecture_fname: str,
+    weight_fname: str,
     verbose: bool,
 ):
     """Benchmark finetuned models."""
@@ -129,6 +147,14 @@ def evaluate(
     model_ids = list(model_id)
     tasks = list(task)
     auth: Union[str, bool] = auth_token if auth_token != "" else use_auth_token
+    architecture_fname_or_none: Optional[str] = architecture_fname
+    weight_fname_or_none: Optional[str] = weight_fname
+
+    # Set `arc_fname` and `weight_fname` to None if they are "None"
+    if architecture_fname_or_none == "None":
+        architecture_fname_or_none = None
+    if weight_fname_or_none == "None":
+        weight_fname_or_none = None
 
     # Initialise the benchmarker class
     evaluator = Evaluator(
@@ -140,6 +166,8 @@ def evaluate(
         track_carbon_emissions=track_carbon_emissions,
         country_code=CountryCode(country_code.lower()),
         prefer_device=Device(prefer_device.lower()),
+        architecture_fname=architecture_fname_or_none,
+        weight_fname=weight_fname_or_none,
         verbose=verbose,
     )
 

--- a/src/aiai_eval/config.py
+++ b/src/aiai_eval/config.py
@@ -164,6 +164,14 @@ class EvaluationConfig:
             Defaults to "cuda".
         only_return_log (bool, optional):
             Whether to only return the log. Defaults to False.
+        architecture_fname (str or None, optional):
+            The name of the architecture file, if local models are used. If None, the
+            architecture file will be automatically detected as the first Python script
+            in the model directory. Defaults to None.
+        weight_fname (str or None, optional):
+            The name of the file containing the model weights, if local models are
+            used. If None, the weight file will be automatically detected as the first
+            "*.bin" file in the model directory. Defaults to None.
         testing (bool, optional):
             Whether a unit test is being run. Defaults to False.
     """
@@ -178,6 +186,8 @@ class EvaluationConfig:
     country_code: CountryCode
     prefer_device: Device
     only_return_log: bool = False
+    architecture_fname: Optional[str] = None
+    weight_fname: Optional[str] = None
     testing: bool = False
 
     @property

--- a/src/aiai_eval/config.py
+++ b/src/aiai_eval/config.py
@@ -213,12 +213,32 @@ class ModelConfig:
     Attributes:
         model_id (str):
             The ID of the model.
+        tokenizer_id (str):
+            The ID of the tokenizer.
         revision (str):
             The revision of the model.
         framework (Framework):
             The framework of the model.
+        id2label (None or list of str):
+            The model's mapping from ID to label. If None, the model does not have a
+            mapping from ID to label.
+        label2id (None or dict of str to int, optional):
+            The model's mapping from label to ID. If None, the model does not have a
+            mapping from label to ID. Defaults to None.
+        num_labels (None or int):
+            The number of labels in the model. If None, the model does not have a
+            mapping between labels and IDs.
     """
 
     model_id: str
+    tokenizer_id: str
     revision: str
     framework: Framework
+    id2label: Optional[List[str]]
+    label2id: Optional[Dict[str, int]] = None
+
+    @property
+    def num_labels(self) -> Union[int, None]:
+        if self.id2label is None:
+            return None
+        return len(self.id2label)

--- a/src/aiai_eval/evaluator.py
+++ b/src/aiai_eval/evaluator.py
@@ -184,7 +184,7 @@ class Evaluator:
 
         except Exception as e:
             if self.evaluation_config.verbose:
-                logger.debug(traceback.format_exc())
+                raise e
             else:
                 logger.error(f"{type(e).__name__}: {e}")
             return dict(error=dict(type=type(e), message=str(e)))

--- a/src/aiai_eval/evaluator.py
+++ b/src/aiai_eval/evaluator.py
@@ -4,7 +4,7 @@ import json
 import logging
 from collections import defaultdict
 from pathlib import Path
-from typing import Dict, List, Sequence, Union
+from typing import Dict, List, Optional, Sequence, Union
 
 from .config import EvaluationConfig, TaskConfig
 from .enums import CountryCode, Device
@@ -47,6 +47,14 @@ class Evaluator:
             Defaults to "cuda".
         only_return_log (bool, optional):
             Whether to only return the log of the evaluation. Defaults to False.
+        architecture_fname (str or None, optional):
+            The name of the architecture file, if local models are used. If None, the
+            architecture file will be automatically detected as the first Python script
+            in the model directory. Defaults to None.
+        weight_fname (str or None, optional):
+            The name of the file containing the model weights, if local models are
+            used. If None, the weight file will be automatically detected as the first
+            "*.bin" file in the model directory. Defaults to None.
         verbose (bool, optional):
             Whether to output additional output. Defaults to False.
 
@@ -70,6 +78,8 @@ class Evaluator:
         country_code: Union[str, CountryCode] = CountryCode.EMPTY,  # type: ignore[attr-defined]
         prefer_device: Device = Device.CUDA,
         only_return_log: bool = False,
+        architecture_fname: Optional[str] = None,
+        weight_fname: Optional[str] = None,
         verbose: bool = False,
     ):
         # If `country_code` is a string then convert it to a `CountryCode` enum
@@ -89,6 +99,8 @@ class Evaluator:
             track_carbon_emissions=track_carbon_emissions,
             country_code=country_code_enum,
             prefer_device=prefer_device,
+            architecture_fname=architecture_fname,
+            weight_fname=weight_fname,
             only_return_log=only_return_log,
         )
 

--- a/src/aiai_eval/evaluator.py
+++ b/src/aiai_eval/evaluator.py
@@ -2,7 +2,6 @@
 
 import json
 import logging
-import traceback
 from collections import defaultdict
 from pathlib import Path
 from typing import Dict, List, Optional, Sequence, Union

--- a/src/aiai_eval/evaluator.py
+++ b/src/aiai_eval/evaluator.py
@@ -137,47 +137,53 @@ class Evaluator:
                 of the datasets, with values being new dictionaries having the model
                 IDs as keys.
         """
-        # Prepare the model IDs and tasks
-        model_ids = self._prepare_model_ids(model_id)
-        task_configs = self._prepare_task_configs(task_name=task)
+        try:
+            # Prepare the model IDs and tasks
+            model_ids = self._prepare_model_ids(model_id)
+            task_configs = self._prepare_task_configs(task_name=task)
 
-        # If there are multiple models and/or tasks specified, then we log an initial
-        # message containing all the upcoming evaluations. The individual (model, task)
-        # pairs will also be logged individually later
-        if len(model_ids) > 1 or len(task_configs) > 1:
+            # If there are multiple models and/or tasks specified, then we log an
+            # initial message containing all the upcoming evaluations. The individual
+            # (model, task) pairs will also be logged individually later
+            if len(model_ids) > 1 or len(task_configs) > 1:
 
-            # Prepare model string for logging
-            if len(model_ids) == 1:
-                model_str = f"{model_ids[0]} model"
-            else:
-                model_str = ", ".join(model_id for model_id in model_ids[:-1])
-                model_str += f" and {model_ids[-1]} models"
+                # Prepare model string for logging
+                if len(model_ids) == 1:
+                    model_str = f"{model_ids[0]} model"
+                else:
+                    model_str = ", ".join(model_id for model_id in model_ids[:-1])
+                    model_str += f" and {model_ids[-1]} models"
 
-            # Prepare task string for logging
-            if len(task_configs) == 1:
-                task_str = f"{task_configs[0].pretty_name} task"
-            else:
-                task_str = ", ".join(cfg.pretty_name for cfg in task_configs[:-1])
-                task_str += f" and {task_configs[-1].pretty_name} tasks"
+                # Prepare task string for logging
+                if len(task_configs) == 1:
+                    task_str = f"{task_configs[0].pretty_name} task"
+                else:
+                    task_str = ", ".join(cfg.pretty_name for cfg in task_configs[:-1])
+                    task_str += f" and {task_configs[-1].pretty_name} tasks"
 
-            # Log status
-            logger.info(f"Evaluating the {model_str} on the {task_str}.")
+                # Log status
+                logger.info(f"Evaluating the {model_str} on the {task_str}.")
 
-        # Evaluate all the models in `model_ids` on all the datasets in `dataset_tasks`
-        for task_config in task_configs:
-            for m_id in model_ids:
-                self._evaluate_single(
-                    task_config=task_config,
-                    model_id=m_id,
-                )
+            # Evaluate all the models in `model_ids` on all the datasets in
+            # `dataset_tasks`
+            for task_config in task_configs:
+                for m_id in model_ids:
+                    self._evaluate_single(
+                        task_config=task_config,
+                        model_id=m_id,
+                    )
 
-        # Save the evaluation results
-        if self.evaluation_config.save_results:
-            output_path = Path.cwd() / "aiai_evaluation_results.json"
-            with output_path.open("w") as f:
-                json.dump(self.evaluation_results, f)
+            # Save the evaluation results
+            if self.evaluation_config.save_results:
+                output_path = Path.cwd() / "aiai_evaluation_results.json"
+                with output_path.open("w") as f:
+                    json.dump(self.evaluation_results, f)
 
-        return self.evaluation_results
+            return self.evaluation_results
+
+        except Exception as e:
+            logger.error(f"{type(e).__name__}: {e}")
+            return dict(error=dict(type=type(e), message=str(e)))
 
     def _prepare_model_ids(
         self,

--- a/src/aiai_eval/evaluator.py
+++ b/src/aiai_eval/evaluator.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+import traceback
 from collections import defaultdict
 from pathlib import Path
 from typing import Dict, List, Optional, Sequence, Union
@@ -182,7 +183,10 @@ class Evaluator:
             return self.evaluation_results
 
         except Exception as e:
-            logger.error(f"{type(e).__name__}: {e}")
+            if self.evaluation_config.verbose:
+                logger.debug(traceback.format_exc())
+            else:
+                logger.error(f"{type(e).__name__}: {e}")
             return dict(error=dict(type=type(e), message=str(e)))
 
     def _prepare_model_ids(

--- a/src/aiai_eval/local_model_utils.py
+++ b/src/aiai_eval/local_model_utils.py
@@ -122,7 +122,7 @@ def load_local_pytorch_model(
         for arg in model_args
     }
 
-    # Initialize the model with the (potentiall empty) set of keyword arguments
+    # Initialize the model with the (potentially empty) set of keyword arguments
     model = model_cls(**model_kwargs)
 
     # Load the model weights
@@ -301,13 +301,13 @@ def get_from_config(
 
                 # Define the base user prompt
                 base_prompt = (
-                    "The configuration did not contain the {key!r} entry. Please "
+                    f"The configuration did not contain the {key!r} entry. Please "
                     "specify its value"
                 )
                 if user_prompt_default_value is not None:
                     user_prompt = (
-                        "The configuration did not contain the {key!r} entry. Press "
-                        "Enter to use the default value {user_prompt_default_value!r} "
+                        f"The configuration did not contain the {key!r} entry. Press "
+                        f"Enter to use the default value {user_prompt_default_value!r} "
                         "or specify a new value"
                     )
 

--- a/src/aiai_eval/local_model_utils.py
+++ b/src/aiai_eval/local_model_utils.py
@@ -1,0 +1,354 @@
+"""Utility functions related to loading local models."""
+
+import inspect
+import json
+import sys
+from importlib import import_module
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Type, Union, get_type_hints
+
+import torch
+import torch.nn as nn
+from transformers.models.auto.tokenization_auto import AutoTokenizer
+from transformers.tokenization_utils_base import PreTrainedTokenizerBase
+
+from .config import ModelConfig, TaskConfig
+from .enums import Framework
+from .model_adjustment import adjust_model_to_task
+
+
+def load_local_pytorch_model(
+    model_config: ModelConfig,
+    device: str,
+    task_config: TaskConfig,
+    architecture_fname: Optional[Union[str, Path]] = None,
+    weight_fname: Optional[Union[str, Path]] = None,
+) -> Dict[str, Union[nn.Module, PreTrainedTokenizerBase]]:
+    """Load a local PyTorch model from a path.
+
+    Args:
+        model_config (ModelConfig):
+            The configuration of the model.
+        device (str):
+            Device to load the model onto.
+        task_config (TaskConfig):
+            The task configuration.
+        architecture_fname (str or Path or None, optional):
+            Name of the file containing the model architecture, which is located inside
+            the model folder. If None then the first Python script found in the model
+            folder will be used. Defaults to None.
+        weight_fname (str or Path or None, optional):
+            Name of the file containing the model weights, which is located inside
+            the model folder. If None then the first file found in the model folder
+            ending with ".bin" will be used. Defaults to None.
+        config_fname (str or Path or None, optional):
+            Name of the file containing the model configuration, which is located
+            inside the model folder. If None then the first file found in the model
+            folder ending with ".json" will be used. If no file is found then the the
+            configuration will be taken from the task configuration. In other words,
+            assume that the model is configured in the same way as the dataset.
+            Defaults to None.
+
+    Returns:
+        dict:
+            A dictionary containing the model and tokenizer.
+    """
+    # Ensure that the model_folder is a Path object
+    model_folder = Path(model_config.model_id)
+
+    # Add the model folder to PATH
+    sys.path.insert(0, str(model_folder))
+
+    # If no architecture_fname is provided, then use the first Python script found
+    if architecture_fname is None:
+        architecture_path = next(model_folder.glob("*.py"))
+    else:
+        architecture_path = model_folder / architecture_fname
+
+    # If no weight_fname is provided, then use the first file found ending with ".bin"
+    if weight_fname is None:
+        weight_path = next(model_folder.glob("*.bin"))
+    else:
+        weight_path = model_folder / weight_fname
+
+    # Import the module containing the model architecture
+    module_name = architecture_path.stem
+    module = import_module(module_name)
+
+    # Get the candidates for the model architecture class, being all classes in the
+    # loaded module that are subclasses of `torch.nn.Module`, and which come from the
+    # desired module (as opposed to being imported from elsewhere)
+    model_candidates = [
+        obj
+        for _, obj in module.__dict__.items()
+        if isinstance(obj, type)
+        and issubclass(obj, nn.Module)
+        and obj.__module__ == module_name
+    ]
+
+    # If there are no candidates, raise an error
+    if not model_candidates:
+        raise ValueError(f"No model architecture found in {architecture_path}")
+
+    # Pick the first candidate
+    model_cls = model_candidates[0]
+
+    # Get the arguments for the class initializer
+    model_args = list(inspect.signature(model_cls).parameters)
+
+    # Remove the arguments that have default values
+    defaults_tuple = model_cls.__init__.__defaults__  # type: ignore[misc]
+    model_args = model_args[: -len(defaults_tuple)]
+
+    # Get the type hints for the class initializer
+    type_hints = get_type_hints(model_cls.__init__)  # type: ignore[misc]
+
+    # If any of the arguments are not in the type hints, raise an error
+    for arg in model_args:
+        if arg not in type_hints:
+            raise ValueError(
+                f"A type hint or default value for the {arg!r} argument of the "
+                f"{model_cls.__name__!r} class is missing. Please specify either "
+                f"in the {architecture_path.name!r} file."
+            )
+
+    # Fetch the model keyword arguments from the local configuration
+    model_kwargs = {
+        arg: get_from_config(
+            key=arg,
+            expected_type=type_hints[arg],
+            model_folder=model_folder,
+        )
+        for arg in model_args
+    }
+
+    # Initialize the model with the (potentiall empty) set of keyword arguments
+    model = model_cls(**model_kwargs)
+
+    # Load the model weights
+    state_dict = torch.load(weight_path, map_location=torch.device("cpu"))
+    model.load_state_dict(state_dict)
+
+    # Set the model to evaluation mode, making its predictions deterministic
+    model.eval()
+
+    # Move the model to the specified device
+    model.to(device)
+
+    # Adjust the model to the task
+    adjust_model_to_task(
+        model=model,
+        model_config=model_config,
+        task_config=task_config,
+    )
+
+    # Load the tokenizer
+    tokenizer = AutoTokenizer.from_pretrained(model_config.tokenizer_id)
+
+    # Return the model with the loaded weights
+    return dict(model=model, tokenizer=tokenizer)
+
+
+def model_exists_locally(
+    model_id: Union[str, Path],
+    architecture_fname: Optional[Union[str, Path]] = None,
+    weight_fname: Optional[Union[str, Path]] = None,
+) -> bool:
+    """Check if a model exists locally.
+
+    Args:
+        model_id (str or Path):
+            Path to the model folder.
+        architecture_fname (str or Path or None, optional):
+            Name of the file containing the model architecture, which is located inside
+            the model folder. If None then the first Python script found in the model
+            folder will be used. Defaults to None.
+        weight_fname (str or Path or None, optional):
+            Name of the file containing the model weights, which is located inside
+            the model folder. If None then the first file found in the model folder
+            ending with ".bin" will be used. Defaults to None.
+
+    Returns:
+        bool:
+            Whether the model exists locally.
+    """
+    # Ensure that the model_folder is a Path object
+    model_folder = Path(model_id)
+
+    # If no architecture_fname is provided, then use the first Python script found
+    if architecture_fname is None:
+        try:
+            architecture_path = next(model_folder.glob("*.py"))
+        except StopIteration:
+            return False
+    else:
+        architecture_path = model_folder / architecture_fname
+
+    # If no weight_fname is provided, then use the first file found ending with ".bin"
+    if weight_fname is None:
+        try:
+            weight_path = next(model_folder.glob("*.bin"))
+        except StopIteration:
+            return False
+    else:
+        weight_path = model_folder / weight_fname
+
+    # Check if the model architecture and weights exist
+    return architecture_path.exists() and weight_path.exists()
+
+
+def get_model_config_locally(
+    model_folder: Union[str, Path],
+    dataset_id2label: List[str],
+) -> ModelConfig:
+    """Get the model configuration from a local model.
+
+    Args:
+        model_folder (str or Path):
+            Path to the model folder.
+        dataset_id2label (list of str):
+            List of labels in the dataset.
+
+    Returns:
+        ModelConfig:
+            The model configuration.
+    """
+    return ModelConfig(
+        model_id=Path(model_folder).name,
+        tokenizer_id=get_from_config(
+            key="tokenizer_id",
+            expected_type=str,
+            model_folder=model_folder,
+            user_prompt="Please specify the Hugging Face ID of the tokenizer to use: ",
+        ),
+        revision="",
+        framework=Framework.PYTORCH,
+        id2label=get_from_config(
+            key="id2label",
+            expected_type=list,
+            model_folder=model_folder,
+            user_prompt="Please specify the labels in the order the model was trained "
+            "(comma-separated), or press enter to use the default values "
+            f"[{', '.join(dataset_id2label)}]: ",
+            user_prompt_default_value=dataset_id2label,
+        ),
+    )
+
+
+def get_from_config(
+    key: str,
+    expected_type: Type,
+    model_folder: Union[str, Path],
+    default_value: Optional[Any] = None,
+    user_prompt: Optional[str] = None,
+    user_prompt_default_value: Optional[Any] = None,
+) -> Any:
+    """Get an attribute from the local model configuration.
+
+    If the attribute is not found in the local model configuration, then the user
+    will be prompted to enter it, after which it will be saved to the local model
+    configuration. If the configuration file does not exist, then a new one will be
+    created named `config.json`.
+
+    Args:
+        key (str):
+            The key to get from the configuration.
+        expected_type (Type):
+            The expected type of the value.
+        model_folder (str or Path):
+            Path to the model folder.
+        default_value (Any or None, optional):
+            The default value to use if the attribute is not found in the local model
+            configuration. If None then the user will be prompted to enter the value.
+            Defaults to None.
+        user_prompt (str or None, optional):
+            The prompt to show the user when asking for the value. If None then the
+            prompt will be automatically generated. Defaults to None.
+        user_prompt_default_value (Any or None, optional):
+            The default value that a user can press Enter to use, when prompted. If
+            None then the user cannot choose a default value. Defaults to None.
+
+    Returns:
+        Any:
+            The value of the key, of data type `expected_type`.
+    """
+    # Ensure that the model_folder is a Path object
+    model_folder = Path(model_folder)
+
+    # Get the candidate configuration files
+    config_paths = list(model_folder.glob("*.json"))
+
+    # If there isn't a config then we set it to a blank dictionary. Otherwise, we load
+    # the config file
+    if not config_paths:
+        config_path = model_folder / "config.json"
+        config = dict()
+    else:
+        config_path = config_paths[0]
+        config = json.loads(config_path.read_text())
+
+    # If the key is not in the config then we either use the default value or prompt
+    # the user to enter it
+    if key not in config:
+
+        # If the default value is set and is of the correct type, then we use it
+        if default_value is not None and isinstance(default_value, expected_type):
+            config[key] = default_value
+
+        # Otherwise, we prompt the user to enter the value
+        else:
+            if user_prompt is None:
+
+                # Define the base user prompt
+                base_prompt = (
+                    "The configuration did not contain the {key!r} entry. Please "
+                    "specify its value"
+                )
+                if user_prompt_default_value is not None:
+                    user_prompt = (
+                        "The configuration did not contain the {key!r} entry. Press "
+                        "Enter to use the default value {user_prompt_default_value!r} "
+                        "or specify a new value"
+                    )
+
+                if expected_type is bool:
+                    user_prompt = f"{base_prompt} (true/false): "
+                elif expected_type is list:
+                    user_prompt = f"{base_prompt} (comma-separated): "
+                elif expected_type is dict:
+                    user_prompt = f"{base_prompt} (key=value, comma-separated): "
+                else:
+                    user_prompt = f"{base_prompt}: "
+
+            # Prompt the user to enter the value
+            user_input = input(user_prompt)
+
+            # If the user input is blank (i.e. they pressed Enter) and there is a
+            # default value, then we use the default value
+            if not user_input and user_prompt_default_value is not None:
+                config[key] = user_prompt_default_value
+
+            # Otherwise, we parse the user input, depending on the expected type
+            else:
+                if expected_type is str:
+                    config[key] = user_input
+                elif expected_type is int:
+                    config[key] = int(user_input)
+                elif expected_type is float:
+                    config[key] = float(user_input)
+                elif expected_type is bool:
+                    config[key] = user_input.lower() == "true"
+                elif expected_type is list:
+                    config[key] = user_input.split()
+                elif expected_type is dict:
+                    config[key] = dict(
+                        item.split("=") for item in user_input.split(",")
+                    )
+
+        # Save the new modified config
+        if not config_path.exists():
+            config_path.touch()
+        config_path.write_text(json.dumps(config, indent=4))
+
+    # Return the value of the key
+    return config[key]

--- a/src/aiai_eval/local_model_utils.py
+++ b/src/aiai_eval/local_model_utils.py
@@ -50,6 +50,21 @@ def load_local_pytorch_model(
             folder, or if the model architecture file does not contain a class
             subclassing `torch.nn.Module`.
     """
+    # TEMPORARY: If the model's `id2label` mapping has fewer labels than the dataset,
+    # then raise an informative error. This is a temporary fix until we have a better
+    # solution for handling this case.
+    if model_config.id2label is not None and len(model_config.id2label) < len(
+        task_config.id2label
+    ):
+        raise ValueError(
+            f"The model {model_config.model_id!r} has fewer labels than the dataset "
+            f"{task_config.name!r} (the model has the labels {model_config.id2label} "
+            f"and the dataset has the labels {task_config.id2label}). We do not "
+            "currently support this case. If the above-mentioned model labels are "
+            "wrong, then please adjust these in the configuration JSON file, located "
+            f"in the {model_config.model_id!r} folder."
+        )
+
     # Ensure that the model_folder is a Path object
     model_folder = Path(model_config.model_id)
 

--- a/src/aiai_eval/model_loading.py
+++ b/src/aiai_eval/model_loading.py
@@ -11,6 +11,11 @@ from .hf_hub_utils import (
     model_exists_on_hf_hub,
     model_is_private_on_hf_hub,
 )
+from .local_model_utils import (
+    get_model_config_locally,
+    load_local_pytorch_model,
+    model_exists_locally,
+)
 from .spacy_utils import (
     get_model_config_from_spacy,
     load_spacy_model,
@@ -52,12 +57,22 @@ def load_model(
         model_config.framework = Framework.PYTORCH
 
     if model_config.framework == Framework.PYTORCH:
-        return load_model_from_hf_hub(
-            model_config=model_config,
-            from_flax=from_flax,
-            task_config=task_config,
-            evaluation_config=evaluation_config,
-        )
+
+        if model_exists_on_hf_hub(model_id=model_config.model_id):
+            return load_model_from_hf_hub(
+                model_config=model_config,
+                from_flax=from_flax,
+                task_config=task_config,
+                evaluation_config=evaluation_config,
+            )
+        elif model_exists_locally(model_id=model_config.model_id):
+            return load_local_pytorch_model(
+                model_config=model_config,
+                device=evaluation_config.device,
+                task_config=task_config,
+            )
+        else:
+            raise ModelDoesNotExist(model_id=model_config.model_id)
 
     elif model_config.framework == Framework.SPACY:
         return load_spacy_model(model_id=model_config.model_id)
@@ -66,12 +81,16 @@ def load_model(
         raise InvalidFramework(model_config.framework)
 
 
-def get_model_config(model_id: str, evaluation_config: EvaluationConfig) -> ModelConfig:
-    """Fetches configuration for a model from the Hugging Face Hub.
+def get_model_config(
+    model_id: str, task_config: TaskConfig, evaluation_config: EvaluationConfig
+) -> ModelConfig:
+    """Fetches configuration for a model.
 
     Args:
         model_id (str):
-            The full Hugging Face Hub ID of the model.
+            The ID of the model.
+        task_config (TaskConfig):
+            The task configuration.
         evaluation_config (EvaluationConfig):
             The configuration of the benchmark.
 
@@ -85,11 +104,14 @@ def get_model_config(model_id: str, evaluation_config: EvaluationConfig) -> Mode
         ModelDoesNotExist:
             If the model id does not exist on the Hugging Face Hub.
     """
-    # Check if model exists on Hugging Face Hub, as well as checking if the model is
-    # private
+    # Check if model exists from any of the available model sources
     model_on_hf_hub = model_exists_on_hf_hub(model_id=model_id)
     model_is_private = model_is_private_on_hf_hub(model_id=model_id)
+    model_on_spacy = model_exists_on_spacy(model_id=model_id)
+    model_is_local = model_exists_locally(model_id=model_id)
 
+    # If the model exists on the Hugging Face Hub, then fetch the model config from
+    # there
     if model_on_hf_hub:
 
         # If the model is private and an authentication token has not been provided,
@@ -102,13 +124,17 @@ def get_model_config(model_id: str, evaluation_config: EvaluationConfig) -> Mode
             model_id=model_id, evaluation_config=evaluation_config
         )
 
-    else:
-        # Check if model exists as a spaCy model
-        model_on_spacy = model_exists_on_spacy(model_id=model_id)
-
-        # If it does not exist on Hugging Face Hub or as a spaCy model, raise an error
-        if not model_on_hf_hub and not model_on_spacy:
-            raise ModelDoesNotExist(model_id=model_id)
-
-        # Otherwise, load the model configuration from spaCy
+    # Otherwise, if the model exists on Spacy, then fetch the model config from there
+    elif model_on_spacy:
         return get_model_config_from_spacy(model_id=model_id)
+
+    # Otherwise, if the model exists locally, then fetch the model config from there
+    elif model_is_local:
+        return get_model_config_locally(
+            model_folder=model_id,
+            dataset_id2label=task_config.id2label,
+        )
+
+    # If it does not exist on any of the available model sources, raise an error
+    else:
+        raise ModelDoesNotExist(model_id=model_id)

--- a/src/aiai_eval/model_loading.py
+++ b/src/aiai_eval/model_loading.py
@@ -70,6 +70,7 @@ def load_model(
                 model_config=model_config,
                 device=evaluation_config.device,
                 task_config=task_config,
+                evaluation_config=evaluation_config,
             )
         else:
             raise ModelDoesNotExist(model_id=model_config.model_id)

--- a/src/aiai_eval/question_answering.py
+++ b/src/aiai_eval/question_answering.py
@@ -8,7 +8,7 @@ from datasets.arrow_dataset import Dataset
 from transformers.data.data_collator import DataCollator, default_data_collator
 from transformers.tokenization_utils_base import BatchEncoding, PreTrainedTokenizerBase
 
-from .config import TaskConfig
+from .config import ModelConfig, TaskConfig
 from .exceptions import FrameworkCannotHandleTask
 from .task import Task
 
@@ -33,7 +33,7 @@ class QuestionAnswering(Task):
         self,
         examples: BatchEncoding,
         tokenizer: PreTrainedTokenizerBase,
-        pytorch_model_config: dict,
+        model_config: ModelConfig,
         task_config: TaskConfig,
     ) -> BatchEncoding:
         return prepare_test_examples(

--- a/src/aiai_eval/spacy_utils.py
+++ b/src/aiai_eval/spacy_utils.py
@@ -94,4 +94,10 @@ def get_model_config_from_spacy(model_id: str) -> ModelConfig:
         ModelConfig:
             The model configuration.
     """
-    return ModelConfig(model_id=model_id, revision="", framework=Framework.SPACY)
+    return ModelConfig(
+        model_id=model_id,
+        tokenizer_id="",
+        revision="",
+        framework=Framework.SPACY,
+        id2label=None,
+    )

--- a/src/aiai_eval/task.py
+++ b/src/aiai_eval/task.py
@@ -34,7 +34,7 @@ from .exceptions import (
 from .metric_configs import EMISSIONS, POWER
 from .model_loading import get_model_config, load_model
 from .scoring import log_scores
-from .utils import clear_memory, enforce_reproducibility
+from .utils import block_terminal_output, clear_memory, enforce_reproducibility
 
 # Set up a logger
 logger = logging.getLogger(__name__)
@@ -87,6 +87,9 @@ class Task(ABC):
             InvalidEvaluation:
                 If an error occurs during evaluation.
         """
+        # Ensure that terminal output is blocked
+        block_terminal_output()
+
         # Fetch the model config
         model_config = get_model_config(
             model_id=model_id,

--- a/src/aiai_eval/task.py
+++ b/src/aiai_eval/task.py
@@ -34,7 +34,7 @@ from .exceptions import (
 from .metric_configs import EMISSIONS, POWER
 from .model_loading import get_model_config, load_model
 from .scoring import log_scores
-from .utils import block_terminal_output, clear_memory, enforce_reproducibility
+from .utils import clear_memory, enforce_reproducibility
 
 # Set up a logger
 logger = logging.getLogger(__name__)
@@ -87,9 +87,6 @@ class Task(ABC):
             InvalidEvaluation:
                 If an error occurs during evaluation.
         """
-        # Ensure that terminal output is blocked
-        block_terminal_output()
-
         # Fetch the model config
         model_config = get_model_config(
             model_id=model_id,

--- a/src/aiai_eval/utils.py
+++ b/src/aiai_eval/utils.py
@@ -15,6 +15,7 @@ import requests
 import torch
 from datasets.utils import disable_progress_bar
 from requests import RequestException
+from transformers.utils.logging import set_verbosity_error
 from wasabi import msg as wasabi_msg
 
 from .enums import Device, Framework
@@ -147,6 +148,9 @@ def block_terminal_output():
 
     # Disable the tokeniser progress bars
     disable_progress_bar()
+
+    # Disable the transformers logging
+    set_verbosity_error()
 
 
 def internet_connection_available() -> bool:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,7 +57,11 @@ def model_configs(evaluation_config, task_config):
         "offensive-text-classification": ["DaNLP/da-electra-hatespeech-detection"],
     }
     yield [
-        get_model_config(model_id=model_id, evaluation_config=evaluation_config)
+        get_model_config(
+            model_id=model_id,
+            task_config=task_config,
+            evaluation_config=evaluation_config,
+        )
         for model_id in model_id_mapping[task_config.name]
     ]
 
@@ -103,6 +107,6 @@ def model_total_scores(model_configs):
 def spacy_model(model_configs):
     for model_config in model_configs:
         if model_config.framework == "spacy":
-            return load_spacy_model(model_config=model_config)["model"]
+            return load_spacy_model(model_id=model_config.model_id)["model"]
     else:
         return None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -25,6 +25,8 @@ def test_cli_param_names(params):
         "raise_error_on_invalid_model",
         "cache_dir",
         "prefer_device",
+        "architecture_fname",
+        "weight_fname",
         "verbose",
         "help",
     }
@@ -43,4 +45,6 @@ def test_cli_param_types(params):
     assert params["cache_dir"] == STRING
     assert isinstance(params["prefer_device"], Choice)
     assert params["verbose"] == BOOL
+    assert params["architecture_fname"] == STRING
+    assert params["weight_fname"] == STRING
     assert params["help"] == BOOL

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -127,8 +127,10 @@ class TestModelConfig:
     def model_config(self):
         yield ModelConfig(
             model_id="model-id",
+            tokenizer_id="tokenizer-id",
             revision="revision",
             framework=Framework.JAX,
+            id2label=["label1", "label2"],
         )
 
     def test_model_config_is_object(self, model_config):

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -5,7 +5,6 @@ from collections import defaultdict
 import pytest
 
 from src.aiai_eval.evaluator import Evaluator
-from src.aiai_eval.exceptions import ModelDoesNotExist
 from src.aiai_eval.task_factory import TaskFactory
 
 

--- a/tests/test_hf_hub_utils.py
+++ b/tests/test_hf_hub_utils.py
@@ -23,8 +23,10 @@ class TestLoadModelFromHfHub:
     ):
         model_config = ModelConfig(
             model_id="saattrupdan/wav2vec2-xls-r-300m-ftspeech",
+            tokenizer_id="saattrupdan/wav2vec2-xls-r-300m-ftspeech",
             revision="main",
             framework=Framework.PYTORCH,
+            id2label=None,
         )
         task_config_copy = deepcopy(task_config)
         task_config_copy.supertask = "wav-2-vec-2-for-c-t-c"
@@ -39,8 +41,10 @@ class TestLoadModelFromHfHub:
     def test_raise_error_if_model_not_accessible(self, evaluation_config, task_config):
         model_config = ModelConfig(
             model_id="invalid-model-id",
+            tokenizer_id="invalid-model-id",
             revision="main",
             framework=Framework.PYTORCH,
+            id2label=None,
         )
         with pytest.raises(InvalidEvaluation):
             load_model_from_hf_hub(

--- a/tests/test_model_adjustment.py
+++ b/tests/test_model_adjustment.py
@@ -47,34 +47,6 @@ class TestAdjustModelToTask:
         )
         assert set(task_config.id2label).issubset(set(model.config.id2label))
 
-    def test_raise_error_if_gap_in_model_id2label_dict(
-        self,
-        model,
-        model_config,
-        task_config,
-    ):
-        model.config.id2label = {0: "label1", 2: "label2"}
-        with pytest.raises(InvalidEvaluation):
-            adjust_model_to_task(
-                model=model,
-                model_config=model_config,
-                task_config=task_config,
-            )
-
-    def test_raise_error_if_gap_in_model_id2label_list(
-        self,
-        model,
-        model_config,
-        task_config,
-    ):
-        model.config.id2label = ["label"]
-        with pytest.raises(InvalidEvaluation):
-            adjust_model_to_task(
-                model=model,
-                model_config=model_config,
-                task_config=task_config,
-            )
-
 
 class TestAlterClassificationLayer:
     def test_no_change_if_model_has_correct_number_of_labels(self, model, task_config):
@@ -118,7 +90,7 @@ class TestAlterClassificationLayer:
             alter_classification_layer(
                 model=model,
                 model_id2label=model_id2label,
-                old_model_id2label=model.config.id2label,
+                old_model_id2label=list(model.config.id2label),
                 flat_dataset_synonyms=model_id2label,
                 dataset_num_labels=len(model_id2label),
             )

--- a/tests/test_model_loading.py
+++ b/tests/test_model_loading.py
@@ -48,10 +48,12 @@ class TestGetModelConfig:
         yield "invalid-model-id"
 
     def test_model_configs_are_the_same_for_hf_models(
-        self, hf_model_id, evaluation_config
+        self, hf_model_id, evaluation_config, task_config
     ):
         model_config_1 = get_model_config(
-            model_id=hf_model_id, evaluation_config=evaluation_config
+            model_id=hf_model_id,
+            task_config=task_config,
+            evaluation_config=evaluation_config,
         )
         model_config_2 = get_model_config_from_hf_hub(
             model_id=hf_model_id, evaluation_config=evaluation_config
@@ -59,16 +61,20 @@ class TestGetModelConfig:
         assert model_config_1 == model_config_2
 
     def test_model_configs_are_the_same_for_spacy_models(
-        self, spacy_model_id, evaluation_config
+        self, spacy_model_id, evaluation_config, task_config
     ):
         model_config_1 = get_model_config(
-            model_id=spacy_model_id, evaluation_config=evaluation_config
+            model_id=spacy_model_id,
+            task_config=task_config,
+            evaluation_config=evaluation_config,
         )
         model_config_2 = get_model_config_from_spacy(model_id=spacy_model_id)
         assert model_config_1 == model_config_2
 
-    def test_invalid_model_id(self, evaluation_config):
+    def test_invalid_model_id(self, evaluation_config, task_config):
         with pytest.raises(ModelDoesNotExist):
             get_model_config(
-                model_id="invalid-model-id", evaluation_config=evaluation_config
+                model_id="invalid-model-id",
+                task_config=task_config,
+                evaluation_config=evaluation_config,
             )


### PR DESCRIPTION
This PR includes support for local PyTorch models, with the relevant functions located in the `local_model_utils` module.

This assumes that there is a "model folder" where the following are located:
- A Python file which defines the model architecture, as a subclass of `torch.nn.Module`.
- A `.bin` file with the model weights.

A configuration JSON file will be generated in the folder if the doesn't already exist, and the user will be prompted to enter the missing details. This includes:
- `tokenizer_id`: The Hugging Face ID to the tokenizer.
- `id2label`: The labels the model was trained on, in the correct order.
- Any arguments needed in the model initializer, which doesn't have any default values. If they don't have any type hints either then an informative error is shown.

A substantial change is also that I catch _all_ errors and log them using `log.error`, rather than using Python's own error logging. This for instance results in the more friendly:
```
2022-09-15 13:41:31,969 [INFO] <aiai_eval.evaluator>
↳ Evaluating the attack model on the offensive text classification task.
2022-09-15 13:41:35,412 [ERROR] <aiai_eval.evaluator>
↳ ValueError: The model architecture file attack/model.py does not exist.
```

A full traceback can be outputted if `verbose` is set.

This closes #18 