### PR TITLE
Feat/discourse coherence

### DIFF
--- a/src/aiai_eval/evaluator.py
+++ b/src/aiai_eval/evaluator.py
@@ -345,6 +345,19 @@ class Evaluator:
                         metrics=self.evaluation_results[task_name][model_id]["total"],
                         test=self.evaluation_config.testing,
                     )
+                    # Check if response contains an error message
+                    if "error" in task_leaderboard_json:
+                        error_msg = task_leaderboard_json["error"]
+                        logger.info(
+                            f"Could not send results for {model_id} to the "
+                            f"{task_name}-leaderboard. Skipping."
+                        )
+                        logger.debug(f'The error message was "{error_msg}".')
+
+                        # Append the status of the leaderboard post to the status list
+                        status.append(False)
+                        continue
+
                     logger.info(
                         f"Results successfully sent to the {task_name}-leaderboard."
                     )

--- a/src/aiai_eval/sequence_classification.py
+++ b/src/aiai_eval/sequence_classification.py
@@ -154,5 +154,11 @@ def tokenize_and_numericalize(
         ][0]
         raise MissingLabel(label=missing_label, label2id=model_label2id)
 
+    # The numericalization fails if the label is not a string, in which case we
+    # check if it is an integer and if so, we assume it is already numericalized
+    except AttributeError:
+        if not isinstance(examples["labels"][0], int):
+            raise MissingLabel(label=examples["labels"][0], label2id=model_label2id)
+
     # Return the examples, now with numerical labels
     return examples

--- a/src/aiai_eval/task_configs.py
+++ b/src/aiai_eval/task_configs.py
@@ -234,6 +234,32 @@ OFFENSIVE = TaskConfig(
     test_name="test",
 )
 
+DISCOURSE = TaskConfig(
+    name="discourse-coherence-classification",
+    huggingface_id="ajders/ddisco",
+    huggingface_subset=None,
+    supertask="sequence-classification",
+    modality=Modality("text"),
+    metrics=[MCC, MACRO_F1],
+    labels=[
+        LabelConfig(
+            name="LOW_COHERENCE",
+            synonyms=["LABEL_0"],
+        ),
+        LabelConfig(
+            name="MEDIUM_COHERENCE",
+            synonyms=["LABEL_1"],
+        ),
+        LabelConfig(
+            name="HIGH_COHERENCE",
+            synonyms=["LABEL_2"],
+        ),
+    ],
+    feature_column_names=["text"],
+    label_column_name="rating",
+    test_name="test",
+)
+
 ASR = TaskConfig(
     name="automatic-speech-recognition",
     huggingface_id="mozilla-foundation/common_voice_11_0",

--- a/src/aiai_eval/task_configs.py
+++ b/src/aiai_eval/task_configs.py
@@ -236,7 +236,7 @@ OFFENSIVE = TaskConfig(
 
 DISCOURSE = TaskConfig(
     name="discourse-coherence-classification",
-    huggingface_id="ajders/ddisco",
+    huggingface_id="alexandrainst/ddisco",
     huggingface_subset=None,
     supertask="sequence-classification",
     modality=Modality("text"),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,7 +49,7 @@ def task_config(request):
 def model_configs(evaluation_config, task_config):
     model_id_mapping = {
         "sentiment-classification": ["pin/senda"],
-        "discourse-coherence-classification": ["ajders/ddisco_classifier"],
+        "discourse-coherence-classification": ["alexandrainst/da-discourse-coherence-base"],
         "named-entity-recognition": [
             "Maltehb/aelaectra-danish-electra-small-cased-ner-dane",
             "spacy/da_core_news_sm",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,6 +49,7 @@ def task_config(request):
 def model_configs(evaluation_config, task_config):
     model_id_mapping = {
         "sentiment-classification": ["pin/senda"],
+        "discourse-coherence-classification": ["ajders/ddisco_classifier"],
         "named-entity-recognition": [
             "Maltehb/aelaectra-danish-electra-small-cased-ner-dane",
             "spacy/da_core_news_sm",
@@ -99,6 +100,12 @@ def model_total_scores(model_configs):
         "alexandrainst/da-hatespeech-detection-small": dict(
             macro_f1=1.0,
             macro_f1_se=0.0,
+            mcc=0.0,
+            mcc_se=0.0,
+        ),
+        "ajders/ddisco_classifier": dict(
+            macro_f1=0.06666666666666667,
+            macro_f1_se=0.13066666666666665,
             mcc=0.0,
             mcc_se=0.0,
         ),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,7 +49,9 @@ def task_config(request):
 def model_configs(evaluation_config, task_config):
     model_id_mapping = {
         "sentiment-classification": ["pin/senda"],
-        "discourse-coherence-classification": ["alexandrainst/da-discourse-coherence-base"],
+        "discourse-coherence-classification": [
+            "alexandrainst/da-discourse-coherence-base"
+        ],
         "named-entity-recognition": [
             "Maltehb/aelaectra-danish-electra-small-cased-ner-dane",
             "spacy/da_core_news_sm",
@@ -103,7 +105,7 @@ def model_total_scores(model_configs):
             mcc=0.0,
             mcc_se=0.0,
         ),
-        "ajders/ddisco_classifier": dict(
+        "alexandrainst/da-discourse-coherence-base": dict(
             macro_f1=0.06666666666666667,
             macro_f1_se=0.13066666666666665,
             mcc=0.0,


### PR DESCRIPTION
This PR introduces:

1. A new task `discourse_coherence_classification`.
2. Fixes in numericalization of labels, allowing for integer labels in dataset.
3. Handle caught errors from post response, i.e. if we handle the error on the leaderboard side, and return a descriptive error message.