### PR TITLE
Update hf_hub_utils.py (remove deprecated use of `ModelFilter`)

### DIFF
--- a/src/alexandra_ai_eval/hf_hub_utils.py
+++ b/src/alexandra_ai_eval/hf_hub_utils.py
@@ -1,6 +1,6 @@
 """Utility functions related to the Hugging Face Hub."""
 
-from huggingface_hub import HfApi, ModelFilter
+from huggingface_hub import HfApi
 from huggingface_hub.hf_api import ModelInfo
 from huggingface_hub.utils import RepositoryNotFoundError
 from huggingface_hub.utils import HFValidationError
@@ -328,7 +328,7 @@ def get_model_config_from_hf_hub(
     # Fetch the model metadata from the Hugging Face Hub
     try:
         models = api.list_models(
-            filter=ModelFilter(author=author, model_name=model_name),
+            author=author, model_name=model_name,
             token=evaluation_config.token,
         )
 


### PR DESCRIPTION
This PR remove deprecated use of `ModelFilter`. Arguments can now be passed to `list_models` directly. See https://github.com/huggingface/huggingface_hub/issues/2028 for more details.